### PR TITLE
Issue #42 - remove redundant argument and ensure that null timeseries are trapped and discarded

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -365,15 +365,6 @@ stopCluster(wk.cluster)
 ctsm_check_convergence(sediment_assessment$assessment)
 
 
-### tidy up ----
-
-# only retain time series with assessments
-
-sediment_assessment <- local({
-  ok <- sapply(sediment_assessment$assessment, function(i) !is.null(i$summary))
-  ctsm.subset.assessment(sediment_assessment, ok)
-})
-
 # saveRDS(sediment_assessment, file.path("RData", "sediment assessment.rds"))
 
 
@@ -543,14 +534,6 @@ biota_assessment$timeSeries <- biota_assessment$timeSeries %>%
   column_to_rownames(".rownames")
 
 
-
-# only retain time series with assessments
-
-biota_assessment <- local({
-  ok <- sapply(biota_assessment$assessment, function(i) !is.null(i$summary))
-  ctsm.subset.assessment(biota_assessment, ok)
-})
-
 # saveRDS(biota_assessment, file.path("RData", "biota assessment.rds"))
 
 
@@ -613,16 +596,6 @@ water_assessment$assessment[wk_id] <-
 
 ctsm_check_convergence(water_assessment$assessment)
 
-
-
-### tidy up ----
-
-# only retain time series with assessments
-
-water_assessment <- local({
-  ok <- sapply(water_assessment$assessment, function(i) !is.null(i$summary))
-  ctsm.subset.assessment(water_assessment, ok)
-})
 
 # saveRDS(water_assessment, file.path("RData", "water assessment.rds"))
 
@@ -703,7 +676,7 @@ water_web <- ctsm_web_initialise(
 
 ## write tables ----
 
-ctsm.summary.table(
+ctsm_summary_table(
   assessments = list(
     Biota = biota_web, 
     Sediment = sediment_web, 

--- a/example_external_data.r
+++ b/example_external_data.r
@@ -190,13 +190,6 @@ biota_assessment$timeSeries <- biota_assessment$timeSeries %>%
   column_to_rownames(".rownames")
 
 
-# only retain time series with assessments
-
-biota_assessment <- local({
-  ok <- sapply(biota_assessment$assessment, function(i) !is.null(i$summary))
-  ctsm.subset.assessment(biota_assessment, ok)
-})
-
 # saveRDS(biota_assessment, file.path("RData", "biota assessment.rds"))
 
 
@@ -233,7 +226,7 @@ biota_web <- ctsm_web_initialise(
 
 # write table 
 
-ctsm.summary.table(
+ctsm_summary_table(
   assessments = list(Biota = biota_web),
   determinandGroups = webGroups,
   path = file.path("output", "example_external_data")

--- a/example_simple_OSPAR.r
+++ b/example_simple_OSPAR.r
@@ -157,14 +157,6 @@ biota_assessment$timeSeries <- biota_assessment$timeSeries %>%
 
 
 
-# only retain time series with assessments
-
-biota_assessment <- local({
-  ok <- sapply(biota_assessment$assessment, function(i) !is.null(i$summary))
-  ctsm.subset.assessment(biota_assessment, ok)
-})
-
-
 # Summary files ----
 
 # web objects: these are a legacy from a Flash app for displaying results
@@ -200,7 +192,7 @@ biota_web <- ctsm_web_initialise(
 # write summary table 
 # can adjust file location with the path argument
 
-ctsm.summary.table(
+ctsm_summary_table(
   assessments = list(Biota = biota_web), 
   determinandGroups = webGroups,
   path = file.path("output", "example_simple_OSPAR")


### PR DESCRIPTION
This deals with Issue 42
* remove redundant determinands argument from ctsm_web_initialise
* ensure all timeseries in timeSeries object have sufficient data to enable an assessment (previously e..g. some timeseries crept through when normalised data were excluded) and had to be deleted in an ad-hoc manner after the assessment had been run
* other minor syntax tidying up
* tested on all three examples