### PR TITLE
rename station variables

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -203,17 +203,6 @@ biota_data$data <- bind_rows(biota_data$data, wk)
 
 # ad-hoc change to merge methods of analysis for Poland for PYR10H
 
-# biota_data$QA <- mutate(
-#   biota_data$QA, 
-#   metoa = if_else(
-#     alabo %in% "IMWP" & 
-#       determinand %in% "PYR1OH" &
-#       year %in% 2020:2021,
-#     "HPLC-FD", 
-#     metoa
-#   )
-# )  
-
 biota_data$data <- mutate(
   biota_data$data, 
   method_analysis = if_else(

--- a/example_external_data_adjustments.Rmd
+++ b/example_external_data_adjustments.Rmd
@@ -156,9 +156,9 @@ if (!identical(wk_stations, "Inch Lough"))
 biota_data$stations %>% 
   filter(
     country == "Ireland", 
-    station %in% wk_stations
+    station_name %in% wk_stations
   ) %>% 
-  select(station, dataType, startYear, endYear, PURPM)
+  select(station_name, dataType, startYear, endYear, PURPM)
 
 ```      
 
@@ -175,8 +175,8 @@ wk_data <- wk_data %>%
   distinct() %>% 
   mutate(
     station_name = submitted.station,
-  station_code = get_station_code(station_name, "Ireland", biota_data$stations)
-)
+    station_code = get_station_code(station_name, "Ireland", biota_data$stations)
+  )
 
 biota_data$data <- left_join(
   biota_data$data,
@@ -200,7 +200,7 @@ biota_data$data <- biota_data$data %>%
 
 biota_data$stations <- biota_data$stations %>%
   mutate(
-    .id = code %in% wk_data$station_code,
+    .id = station_code %in% wk_data$station_code,
     .T = str_split(PURPM, "~") %>% sapply(function(x) "T" %in% x),
     .EF = str_split(dataType, "~") %>% sapply(function(x) "EF" %in% x),
     PURPM = if_else(.id & !.T, paste0(PURPM, "~T"), PURPM),
@@ -414,12 +414,12 @@ wk <- biota_data$stations %>%
   filter(
     country %in% "Sweden",
     grepl("CF", dataType),
-    station %in% c("E/W FLADEN", "Nidingen") |
-      grepl("llbacka", station) | 
-      (grepl("V", station) & grepl("arna", station))
+    station_name %in% c("E/W FLADEN", "Nidingen") |
+      grepl("llbacka", station_name) | 
+      (grepl("V", station_name) & grepl("arna", station_name))
   ) %>%
-  select(code, station) %>%
-  column_to_rownames("code")
+  select(station_code, station_name) %>%
+  column_to_rownames("station_code")
 
 wk
 
@@ -440,11 +440,11 @@ biota_data$data <- mutate(
   .id = country %in% "Sweden" & submitted.station %in% "B-R07",
   
   .change = .id & speciestype %in% "Fish",
-  station_name = if_else(.change, wk["6141", "station"], station_name),
+  station_name = if_else(.change, wk["6141", "station_name"], station_name),
   station_code = if_else(.change, "6141", station_code),
   
   .change = .id & speciestype %in% "Bivalve",
-  station_name = if_else(.change, wk["5747", "station"], station_name),
+  station_name = if_else(.change, wk["5747", "station_name"], station_name),
   station_code = if_else(.change, "5747", station_code),
   
   .id = NULL,
@@ -787,8 +787,8 @@ with(wk_data, table(station_name)) %>%
 ```{r Faroes_3}
 
 wk_station <- biota_data$stations %>% 
-  filter(code == "902") %>% 
-  pull(station)
+  filter(station_code == "902") %>% 
+  pull(station_name)
 ```
 
 For assessment purposes these data are all taken to come from a single station covering the waters around Faroes: specifically `r wk_station`. Here is a summary of the number of measurements by year.
@@ -832,8 +832,8 @@ with(wk_data, table(submitted.station, station_name, useNA = "ifany")) %>%
   print(zero.print = ".")
 
 wk_station <- biota_data$stations %>% 
-  filter(code == "916") %>% 
-  pull(station)
+  filter(station_code == "916") %>% 
+  pull(station_name)
 ```
 
 Somehow everything seems to have matched up, apart for data submitted with station Skuvoy, which needs to be changed to `r wk_station`.

--- a/functions/import_external_data.R
+++ b/functions/import_external_data.R
@@ -162,6 +162,17 @@ add_non_ICES_data <- function(
   AMAP_stations <- as.data.frame(AMAP_stations)
 
 
+  # rename variables to be compatible with new names
+  
+  AMAP_stations <- rename(
+    AMAP_stations,
+    station_code = code,
+    station_name = station,
+    station_latitude = latitude,
+    station_longitude = longitude
+  )
+  
+
   # data checks
   
   if (any(is.na(AMAP_stations)))
@@ -187,7 +198,7 @@ add_non_ICES_data <- function(
   
   # check for no conflicts in station dictionary
   
-  id <- c("country", "station")
+  id <- c("country", "station_name")
   if (any(my_paste(AMAP_stations[id]) %in% my_paste(ICES_data$stations[id])))
     stop("AMAP station replicates a station in the ICES station dictionary", call. = FALSE)
   
@@ -195,7 +206,11 @@ add_non_ICES_data <- function(
   # check for consistency between data and stations
 
   id <- sort(unique(AMAP_data$station_code))
-  ok <- id %in% c(AMAP_stations$code, as.character(ICES_data$stations$code))
+  ok <- id %in% c(
+    AMAP_stations$station_code, 
+    as.character(ICES_data$stations$station_code)
+  )
+  
   if (!all(ok))
     stop(
       "The following stations are in the data file but not the station file or the ICES station ", 
@@ -205,13 +220,16 @@ add_non_ICES_data <- function(
     )
   
   stopifnot(
-    AMAP_data$station_name %in% c(AMAP_stations$station, as.character(ICES_data$stations$station))
+    AMAP_data$station_name %in% c(
+      AMAP_stations$station_name, 
+      as.character(ICES_data$stations$station_name)
+    )
   )
     
   wk <- unique(AMAP_data[c("country", "station_code", "station_name")])
   ok <- my_paste(wk) %in% 
-    c(my_paste(AMAP_stations[c("country", "code", "station")]), 
-      my_paste(ICES_data$stations[c("country", "code", "station")]))
+    c(my_paste(AMAP_stations[c("country", "station_code", "station_name")]), 
+      my_paste(ICES_data$stations[c("country", "station_code", "station_name")]))
 
   if (!all(ok)) {
     cat("Error: the following combinations in the data are not in ICES or AMAP station files:\n")
@@ -228,7 +246,7 @@ add_non_ICES_data <- function(
     dataType = "CF"
   )
     
-
+  
   # construct QA file
     
   AMAP_QA <- data.frame(qalink = 0)

--- a/functions/information_functions.R
+++ b/functions/information_functions.R
@@ -2325,7 +2325,7 @@ get_RECO <- function(code, path = "information") {
 
 # get station code from station name
   
-get_station_code <- function(name, country, stations) {
+get_station_code <- function(station_name, country, stations) {
   
   # gets the station code corresponding to the station name and country from the 
   # station dictionary
@@ -2333,18 +2333,18 @@ get_station_code <- function(name, country, stations) {
   # only works for one country at a time
   
   stopifnot(length(country) == 1)
-  n <- length(name)
+  n <- length(station_name)
   
-  out <- data.frame(station = name, country = country) 
+  out <- data.frame(station_name = station_name, country = country) 
   out <- mutate(out, across(.fns = as.character))
     
   
-  stations <- stations[c("station", "country", "code")]
+  stations <- stations[c("station_name", "country", "station_code")]
   stations <- mutate(stations, across(.fns = as.character)) 
   
-  out <- left_join(out, stations, by = c("station", "country"))
+  out <- left_join(out, stations, by = c("station_name", "country"))
   
   stopifnot(!is.na(out), n == nrow(out))
   
-  out$code
+  out$station_code
 }


### PR DESCRIPTION
 rename station variables in ctsm_obj$stations so that input to ctsm_create_timeSeries is in agreed format
- code --> station_code
- station --> station_name
- name --> station_longname
- latitude --> station_latitude
- longitude --> station_longitude
- MSTAT --> station_type
- WLTYP --> waterbody_type 
tested on all data sets

note that on reflection I changed the new names of MSTAT and WLTYP to be more sensible; I will send you current word document with new input structure

also remove redundant legacy code in ctsm_summary_table