### PR TITLE
make get_basis an argument to timeseries routine

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -250,6 +250,7 @@ biota_timeSeries <- ctsm_create_timeSeries(
     INTS = list(det = "INTSI", action = "bespoke"),
     "LIPIDWT%" = list(det = c("EXLIP%", "FATWT%"), action = "bespoke")
   ),
+  get_basis = get_basis_biota_HELCOM,
   normalise = ctsm_normalise_biota_HELCOM,
   normalise.control = list(
     lipid = list(method = "simple", value = 5), 

--- a/example_external_data.r
+++ b/example_external_data.r
@@ -107,7 +107,8 @@ biota_timeSeries <- ctsm_create_timeSeries(
   biota_data,
   determinands.control = list(
     "LIPIDWT%" = list(det = c("EXLIP%", "FATWT%"), action = "bespoke")
-  )
+  ),
+  get_basis = get_basis_biota_OSPAR
 )
 
 # saveRDS(biota_timeSeries, file.path("RData", "biota timeSeries.rds"))

--- a/example_simple_OSPAR.r
+++ b/example_simple_OSPAR.r
@@ -87,7 +87,8 @@ biota_timeSeries <- ctsm_create_timeSeries(
   determinands.control = list(
     HBCD = list(det = c("HBCDA", "HBCDB", "HBCDG"), action = "sum"),
     "LIPIDWT%" = list(det = c("EXLIP%", "FATWT%"), action = "bespoke")
-  )
+  ), 
+  get_basis = get_basis_biota_OSPAR
 )
 
 # identical (apart from call) to: 

--- a/functions/import_functions.R
+++ b/functions/import_functions.R
@@ -923,6 +923,7 @@ ctsm_create_timeSeries <- function(
   return_early = FALSE, 
   print_code_warnings = FALSE, 
   output = c("time_series", "uncertainties"), 
+  get_basis = get_basis_default,
   normalise = FALSE, 
   normalise.control = list()) {
 
@@ -1549,30 +1550,10 @@ ctsm_create_timeSeries <- function(
   # convert data to basis of assessment
   
 
-  if (info$purpose %in% c("HELCOM", "OSPAR")) {
-    
-    cat("   Converting data to appropriate basis for statistical analysis", fill = TRUE)
+  cat("   Converting data to appropriate basis for statistical analysis", fill = TRUE)
 
-    data <- mutate(
-      data, 
-      new.basis = get_basis(
-        info$purpose, info$compartment, .data$group, .data$matrix, .data$determinand,
-        species = switch(info$compartment, biota = .data$species, NA)
-      ),
-      new.basis = factor(new.basis)
-    )
-  }
-  
+  data$new.basis <- get_basis(data, info$compartment)
 
-  if (info$purpose %in% "AMAP") {
-    
-    cat(
-      "   Converting data to common basis (within station, species, matrix and determinand group)", 
-      fill = TRUE)
-    
-    data <- get_basis(info$purpose, data, info$compartment)
-  }
-    
 
   # don't convert water because already assumed to be on a wet weight basis
   # no DRYWT% data and convert.basis falls over


### PR DESCRIPTION
this removes the dependency on info$purpose

there are four get_basis functions at present:
- default (used for water, sediment and simple biota situations)
- most_common (used in last AMAP assessment) which takes the most common basis reported for each group of data
- biota_OSPAR - the 2023 OSPAR procedure
- biota_HELCOM - the 2023 HELCOM procedure

tested on all data sets