### PR TITLE
Issue 79: missing determinands

### DIFF
--- a/functions/information_functions.R
+++ b/functions/information_functions.R
@@ -220,6 +220,14 @@ ctsm_get_determinands <- function(compartment = c("biota", "sediment", "water"))
   assess_id <- paste0(compartment, "_assess")
   ok <- info.determinand[[assess_id]]
   
+  if (!any(ok)) {
+    stop(
+      "No determinands have been been selected for assessment:\n", 
+      "  please update the determinand reference table or supply the\n",
+      "  determinands directly via the determinands argument."
+    )
+  }
+  
   row.names(info.determinand)[ok]
 }  
 


### PR DESCRIPTION
Traps case where no determinands are marked for assessment in the reference table (or are not supplied directly)

Fixes bug in ctsm_create_timeSeries where auxiliary determinands have no values in the data set - previously the code took data$determinand to be a factor, but now it is a character

Bug fix also generalises code to pick up all relevant auxiliary variables (not just those that were hardwired) and removes another dependency on info$purpose

Tested on all five data sets