### PR TITLE
Make station_code key station variable

### DIFF
--- a/example_external_data.r
+++ b/example_external_data.r
@@ -162,7 +162,7 @@ stopCluster(wk.cluster)
 (wk_check <- ctsm_check_convergence(biota_assessment$assessment))
 
 # this time series has missing standard errors   
-# "Ireland_Lee K Estuary HG Mytilus edulis SB Not_applicable"                       
+# "3371 HG Mytilus edulis SB Not_applicable"                       
 
 # refit with different numerical differencing arguments
 biota_assessment$assessment[wk_check] <- 

--- a/functions/graphics_functions.R
+++ b/functions/graphics_functions.R
@@ -59,8 +59,8 @@ ctsm.web.getKey <- function(info, auxiliary.plot = FALSE, html = FALSE) {
 
   out <- list(media = txt)
 
-  txt <- paste("Station: ", info$station, sep = "")
-  if (!is.na(info$stationName)) txt <- paste(txt, " (", info$stationName, ")", sep = "")
+  txt <- paste("Station: ", info$station_name, sep = "")
+  if (!is.na(info$station_longname)) txt <- paste(txt, " (", info$station_longname, ")", sep = "")
 
   #out$station <- if (html) convert.html.characters(txt) else txt
   out$station <- txt

--- a/functions/imposex_functions.R
+++ b/functions/imposex_functions.R
@@ -139,8 +139,9 @@ imposex.family <- list(
 
 
 
-assess_imposex <- function(data, annualIndex, AC, recent.years, determinand, species, 
-                           station, thetaID, max.year, recent.trend = 20) {
+assess_imposex <- function(
+    data, annualIndex, AC, recent.years, determinand, species, 
+    station_code, thetaID, max.year, recent.trend = 20) {
   
   # main assessment routine for imposex data (imposex functions)
   

--- a/functions/proportional_odds_functions.R
+++ b/functions/proportional_odds_functions.R
@@ -154,7 +154,10 @@ ctsm.VDS.cl <- function(fit, nsim = 1000) {
   namesID <- strsplit(row.names(cl), " ", fixed = TRUE)
   cl$species <- sapply(namesID, function(x) paste(tail(x, n_tail), collapse = " "))
   cl$year <- as.numeric(sapply(namesID, function(x) x[length(x) - n_tail]))
-  cl$station <- sapply(namesID, function(x) paste(head(x, length(x) - n_tail - 1), collapse = " "))
+  cl$station_code <- sapply(
+    namesID, 
+    function(x) paste(head(x, length(x) - n_tail - 1), collapse = " ")
+  )
 
   cl
 }

--- a/functions/reporting_functions.R
+++ b/functions/reporting_functions.R
@@ -93,43 +93,27 @@ ctsm_web_initialise <- function(
 }
 
 
-ctsm_web_setup <- function(assessmentObject) {
+ctsm_web_setup <- function(assessment_obj) {
   
-  # extract timeSeries and stations and get more useful names
-  
-  timeSeries <- assessmentObject$timeSeries
-  timeSeries <- swap.names(timeSeries, "station", "stationID")
-  timeSeries <- within(timeSeries, stationID <- as.character(stationID))
-  
-  stations <- assessmentObject$stations
+  # merge timeSeries with stations
 
+  timeSeries <- assessment_obj$timeSeries
+  
+  timeSeries <- rownames_to_column(timeSeries, ".series")
+  
+  timeSeries <- left_join(
+    timeSeries, 
+    assessment_obj$stations,
+    by = "station_code"
+  )
 
-  # convert station factors to characters for output 
+  timeSeries <- column_to_rownames(timeSeries, ".series")
   
-  stations <- tibble::rownames_to_column(stations, ".rownames")
-  stations <- dplyr::mutate(stations, dplyr::across(where(is.factor), as.character))
-  stations <- tibble::column_to_rownames(stations, ".rownames")
+  assessment_obj$timeSeries <- timeSeries
   
-  
-  # check lower case stationIDs are unique (for unique filenames)
-  
-  wk <- tolower(row.names(stations))
-  if (any(duplicated(wk))) {
-    stop(
-      "stationID not unique when converted to lower case ", 
-      "- might cause difficulties with filenames"
-    )
-  }
-  
-
-  # merge timeSeries and stations  
-  
-  timeSeries <- cbind(timeSeries, stations[timeSeries$stationID, ])
-
-  assessmentObject$timeSeries <- timeSeries
-  assessmentObject
+  assessment_obj
 }
-
+  
 
 
 # mapping functions ----


### PR DESCRIPTION
replace concatenation of country and station_name by station_code as key station variable
ensure all legacy code involving 'station' (the concatenated variable) are replaced by station_code
remove rownames from stations (data and stations now merged using left_join by station_code)
country and station_name no longer passed in data to ctsm_create_timeSeries - only in stations
test on all five data sets