### PR TITLE
No renaming for external data

### DIFF
--- a/example_external_data.r
+++ b/example_external_data.r
@@ -28,7 +28,7 @@ source(file.path(function_path, "support_functions.R"))
 
 info_species_file_id <- "species_2020.csv"
 
-info_AC_type <- "OSPAR"
+info_AC_type <- "EXTERNAL"
 if(tolower(info_AC_type) != tolower("OSPAR") && tolower(info_AC_type) != tolower("HELCOM") && tolower(info_AC_type) != tolower("EXTERNAL")){
   stop("info_AC_type can only be OSPAR, HELCOM, or EXTERNAL")
 }
@@ -59,8 +59,8 @@ values_range_check_species(species, min_value, max_value)
 biota_data <- ctsm_read_data(
   compartment = "biota", 
   purpose = "OSPAR",                               
-  contaminants = "mercury_data.csv", 
-  stations = "station_dictionary.csv", 
+  contaminants = "AMAP_external_data_new_data_only_CAN_MarineMammals.csv", 
+  stations = "AMAP_external_new_stations_only.csv", 
   QA = "quality_assurance.csv",
   path = file.path("data", "example_external_data"), 
   extraction = "2022/01/11",

--- a/functions/import_functions.R
+++ b/functions/import_functions.R
@@ -195,33 +195,36 @@ ctsm_read_stations <- function(infile, path, purpose, region_id) {
     infile, na.strings = c("", "NULL")
   )
   
-  
+  print(info_AC_type)
   # rename columns to suit!
   
   names(stations) <- gsub("Station_", "", names(stations), fixed = TRUE)
 
-  stations <- dplyr::rename(
-    stations, 
-    station_code = Code,
-    country_ISO = Country,
-    country = Country_CNTRY,
-    station_name = Name,
-    station_longname = LongName,
-    station_latitude = Latitude,
-    station_longitude = Longitude,
-    startYear = ActiveFromDate,
-    endYear = ActiveUntilDate,
-    parent_code = AsmtMimeParent,
-    replacedBy = ReplacedBy,
-    programGovernance = ProgramGovernance,
-    dataType = DataType,
-    station_type = MSTAT,
-    waterbody_type = WLTYP
-  )
+  if(info_AC_type != "EXTERNAL") {
+    stations <- dplyr::rename(
+      stations, 
+      station_code = Code,
+      country_ISO = Country,
+      country = Country_CNTRY,
+      station_name = Name,
+      station_longname = LongName,
+      station_latitude = Latitude,
+      station_longitude = Longitude,
+      startYear = ActiveFromDate,
+      endYear = ActiveUntilDate,
+      parent_code = AsmtMimeParent,
+      replacedBy = ReplacedBy,
+      programGovernance = ProgramGovernance,
+      dataType = DataType,
+      station_type = MSTAT,
+      waterbody_type = WLTYP
+    )
 
-  if (purpose %in% c("OSPAR", "AMAP")) {
-    stations <- dplyr::rename(stations, offshore = OSPAR_shore)
-  }  
+    if (purpose %in% c("OSPAR", "AMAP")) {
+      stations <- dplyr::rename(stations, offshore = OSPAR_shore)
+    }  
+  
+  }
 
   # turn following variables into a character
   # code and parent code could be kept as integers, but safer to leave as 
@@ -356,7 +359,7 @@ ctsm_read_contaminants <- function(infile, path, purpose, region_id, data_format
     )
 
   }
-    
+  
   pos <- names(data) %in% region_id
   if (sum(pos) != length(region_id)) {
     stop("not all regional identifiers are in the data extraction")
@@ -386,7 +389,7 @@ ctsm_read_contaminants <- function(infile, path, purpose, region_id, data_format
       method_pretreatment = metpt
     )
     
-  } else if (purpose %in% c("OSPAR", "AMAP")) {
+  } else if (info_AC_type != "EXTERNAL" && purpose %in% c("OSPAR", "AMAP")) {
     
     data <- dplyr::rename(
       data,
@@ -414,24 +417,25 @@ ctsm_read_contaminants <- function(infile, path, purpose, region_id, data_format
   
   
   # variables common across purpose and compartments
-
-  data <- dplyr::rename(
-    data,
-    year = myear, 
-    sample_latitude = latitude,
-    sample_longitude = longitude,
-    determinand = param, 
-    matrix = matrx, 
-    unit = munit, 
-    qalink = tblanalysisid,
-    uncertainty = uncrt,
-    unit_uncertainty = metcu, 
-    replicate = tblparamid, 
-    sample = tblsampleid, 
-    limit_detection = detli,
-    limit_quantification = lmqnt,
-    upload = tbluploadid
-  )
+  if(info_AC_type != "EXTERNAL") {
+    data <- dplyr::rename(
+      data,
+      year = myear, 
+      sample_latitude = latitude,
+      sample_longitude = longitude,
+      determinand = param, 
+      matrix = matrx, 
+      unit = munit, 
+      qalink = tblanalysisid,
+      uncertainty = uncrt,
+      unit_uncertainty = metcu, 
+      replicate = tblparamid, 
+      sample = tblsampleid, 
+      limit_detection = detli,
+      limit_quantification = lmqnt,
+      upload = tbluploadid
+    )
+  }
   
 
   # compartment specific variables

--- a/information/determinand_external_data.csv
+++ b/information/determinand_external_data.csv
@@ -1,7 +1,7 @@
-"determinand","common_name","pargroup","biota_group","sediment_group","water_group","biota_assess","sediment_assess","water_assess","biota_unit","sediment_unit","water_unit","biota_auxiliary","sediment_auxiliary","water_auxiliary","biota_sd_constant","biota_sd_variable","sediment_sd_constant","sediment_sd_variable","water_sd_constant","water_sd_variable","distribution","good_status"
-"HG","Mercury","I-MET","Metals","Metals","Metals",TRUE,FALSE,FALSE,"ug/kg","mg/kg","ug/l","LNMEA, LIPIDWT%, DRYWT%",,,0.541,0.087966,0.002167,0.100382,,,"lognormal","low"
-"LNMEA","mean length","B-BIO","Auxiliary",,,FALSE,FALSE,FALSE,"cm",,,,,,,,,,,,,
-"DRYWT%","dry weight","B-BIO","Auxiliary","Auxiliary",,FALSE,FALSE,FALSE,"%","%",,,,,,,,,,,,
-"EXLIP%","extractable lipid","B-BIO","Auxiliary",,,FALSE,FALSE,FALSE,"%",,,,,,,,,,,,,
-"LIPIDWT%","lipid weight","B-BIO","Auxiliary",,,FALSE,FALSE,FALSE,"%",,,,,,,,,,,,,
-"FATWT%","fat weight","B-BIO","Auxiliary",,,FALSE,FALSE,FALSE,"%",,,,,,,,,,,,,
+determinand,common_name,pargroup,biota_group,sediment_group,water_group,biota_assess,sediment_assess,water_assess,biota_unit,sediment_unit,water_unit,biota_auxiliary,sediment_auxiliary,water_auxiliary,biota_sd_constant,biota_sd_variable,sediment_sd_constant,sediment_sd_variable,water_sd_constant,water_sd_variable,distribution,good_status
+HG,Mercury,I-MET,Metals,Metals,Metals,TRUE,FALSE,FALSE,ug/kg,mg/kg,ug/l,"LNMEA, LIPIDWT%, DRYWT%",,,0.541,0.087966,0.002167,0.100382,,,lognormal,low
+LNMEA,mean length,B-BIO,Auxiliary,,,FALSE,FALSE,FALSE,cm,,,,,,,,,,,,,
+DRYWT%,dry weight,B-BIO,Auxiliary,Auxiliary,,FALSE,FALSE,FALSE,%,%,,,,,,,,,,,,
+EXLIP%,extractable lipid,B-BIO,Auxiliary,,,FALSE,FALSE,FALSE,%,,,,,,,,,,,,,
+LIPIDWT%,lipid weight,B-BIO,Auxiliary,,,FALSE,FALSE,FALSE,%,,,,,,,,,,,,,
+FATWT%,fat weight,B-BIO,Auxiliary,,,FALSE,FALSE,FALSE,%,,,,,,,,,,,,,


### PR DESCRIPTION
- renaming variables for external data removed in read stations function
- renaming variables for external data removed in read contaminants function

Not tested on OSPAR or HELCOM, they need another fix for reading csv files, which I will add next.