### PR TITLE
Data error correction Rmd file crashes:

### DIFF
--- a/example_external_data.r
+++ b/example_external_data.r
@@ -84,11 +84,13 @@ biota_data <- ctsm_read_data(
 
 # the report of the adjustments can be sent anywhere
 
-rmarkdown::render(
-  "example_external_data_adjustments.Rmd", 
-  output_file = "mercury_adjustments.html",
-  output_dir = file.path("output", "example_external_data") 
-)
+if(info_AC_type != "EXTERNAL") {
+  rmarkdown::render(
+    "example_external_data_adjustments.Rmd", 
+    output_file = "mercury_adjustments.html",
+    output_dir = file.path("output", "example_external_data") 
+  )
+}
 
 # saveRDS(biota_data, file.path("RData", "biota data adjusted.rds"))
 


### PR DESCRIPTION
- variables requested in example_external_data_ajustements.Rmd are not present in agreed input format and cause the program to crash
- use data correction Rmd for mercury data example only, otherwise ignore