### PR TITLE
Leading and trailing white space

### DIFF
--- a/functions/import_functions.R
+++ b/functions/import_functions.R
@@ -192,7 +192,7 @@ ctsm_read_stations <- function(infile, path, purpose, region_id) {
   cat("Reading station dictionary from '", infile, "'\n", sep = "")
 
   stations <- read.csv(
-    infile, na.strings = c("", "NULL")
+    infile, na.strings = c("", "NULL"), strip.white = TRUE
   )
   
   print(info_AC_type)
@@ -253,7 +253,7 @@ ctsm_read_contaminants <- function(infile, path, purpose, region_id, data_format
   if (data_format == "old") {  
 
     data <- read.csv(
-      infile, na.strings = c("", "NULL")
+      infile, na.strings = c("", "NULL"), strip.white = TRUE,
     )
       
     #data <- read.table(
@@ -488,7 +488,7 @@ ctsm_read_QA <- function(QA, path, purpose) {
   cat("\nReading QA data from '", infile, "'\n", sep = "")
   
   crm <- read.csv(
-    infile, na.strings = c("", "NULL")
+    infile, na.strings = c("", "NULL"), strip.white = TRUE
   )
 
   names(crm) <- tolower(names(crm))


### PR DESCRIPTION
The conversion to csv files has introduced some trailing white space in the station longname (or else it was already there but trapped in the read.txt command, which has now been replaced).

Have stripped leading and trailing white space in read.csv.

Likely to be useful for external data sets.  Wouldn't expect to see this in ICES data sets from the web server.

Note that the conversion to csv has changed the date in two of the example files (HELCOM sediment, HELCOM water - fortunately not important for these examples)