### PR TITLE
Replicate and pargroup mandatory non-empty variables missing:

### DIFF
--- a/functions/import_functions.R
+++ b/functions/import_functions.R
@@ -110,7 +110,10 @@ ctsm_read_data <- function(
   }
   
   # adding required variables 'replicate' and 'pargroup'
-  data$replicate <- seq(from = 1, to = nrow(data), by = 1)
+  
+  if (!"replicate" %in% names(data)) {
+    data$replicate <- seq(from = 1, to = nrow(data), by = 1)
+  }
   
   if (!"pargroup" %in% names(data)) {
     data$pargroup <- ctsm_get_info("determinand", data$determinand, "pargroup")


### PR DESCRIPTION
- replicate is generated in code as an index.
- pargroup is extracted from determinand reference table.