### PR TITLE
Issue 110

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -111,7 +111,7 @@ sediment_data <- ctsm_read_data(
   stations = file.path("data", "example_HELCOM", "station_dictionary.csv"),
   extraction = "2022/10/06",
   max_year = 2021L,
-  data_format = "new"
+  data_format = "ICES_new"
 )
 
 # sediment_data <- ctsm_read_data(
@@ -137,7 +137,7 @@ water_data <- ctsm_read_data(
   stations = file.path("data", "example_HELCOM", "station_dictionary.csv"), 
   extraction = "2022/10/06",
   max_year = 2021L, 
-  data_format = "new"
+  data_format = "ICES_new"
 )  
 
 # saveRDS(water_data, file.path("RData", "water data.rds"))


### PR DESCRIPTION
- data_format argument now can be "ICES_old", "ICES_new", or "external"
- makes explicit the type of data and cleans up a lot of the code in ctsm_read_data and ctsm_tidy_data
- in due course will replace "ICES_old" and "ICES_new" with "ICES, but need code from ICES first
- have tested on five original test data sets
- haven't tested on external only AMAP data set