### PR TITLE
Issue 115 rename qflag

### DIFF
--- a/data/example_external_data/AMAP_external_data_new_data_only_CAN_MarineMammals.csv
+++ b/data/example_external_data/AMAP_external_data_new_data_only_CAN_MarineMammals.csv
@@ -1,4 +1,4 @@
-﻿country,station_code,station_name,year,species,sex,determinand,matrix,basis,value,unit,qflag,limit_detection,limit_quantification,uncertainty,unit_uncertainty,sample,subseries,sample_latitude,sample_longitude,date,depth,method_pretreatment,method_analysis,method_extraction,n_individual
+﻿country,station_code,station_name,year,species,sex,determinand,matrix,basis,value,unit,censoring,limit_detection,limit_quantification,uncertainty,unit_uncertainty,sample,subseries,sample_latitude,sample_longitude,date,depth,method_pretreatment,method_analysis,method_extraction,n_individual
 Canada,A3,Southern Hudson Bay,2006,Ursus maritimus,F,HG,LI,D,34.42,ug/g,,,,,,A10001,adult_female,,,,,,,,
 Canada,A3,Southern Hudson Bay,2006,Ursus maritimus,M,HG,LI,D,49.1,ug/g,,,,,,A10002,adult_male,,,,,,,,
 Canada,A3,Southern Hudson Bay,2007,Ursus maritimus,M,HG,LI,D,15.97,ug/g,,,,,,A10003,adult_male,,,,,,,,

--- a/data/example_external_data/AMAP_external_data_new_data_only_CAN_PolarBear.csv
+++ b/data/example_external_data/AMAP_external_data_new_data_only_CAN_PolarBear.csv
@@ -1,4 +1,4 @@
-﻿country,station_code,station_name,year,species,sex,determinand,matrix,basis,value,unit,qflag,limit_detection,limit_quantification,uncertainty,unit_uncertainty,sample,subseries,source
+﻿country,station_code,station_name,year,species,sex,determinand,matrix,basis,value,unit,censoring,limit_detection,limit_quantification,uncertainty,unit_uncertainty,sample,subseries,source
 Canada,A3,Southern Hudson Bay,2006,Ursus maritimus,F,HG,LI,D,34.42,ug/g,,,,,,A10001,adult_female,Letcher
 Canada,A3,Southern Hudson Bay,2006,Ursus maritimus,M,HG,LI,D,49.1,ug/g,,,,,,A10002,adult_male,Letcher
 Canada,A3,Southern Hudson Bay,2007,Ursus maritimus,M,HG,LI,D,15.97,ug/g,,,,,,A10003,adult_male,Letcher

--- a/data/example_external_data/AMAP_external_data_new_data_only_CAN_SWE_Other.csv
+++ b/data/example_external_data/AMAP_external_data_new_data_only_CAN_SWE_Other.csv
@@ -1,4 +1,4 @@
-﻿country,station_code,station_name,year,species,sex,determinand,matrix,basis,value,unit,qflag,limit_detection,limit_quantification,uncertainty,unit_uncertainty,sample,subseries,source
+﻿country,station_code,station_name,year,species,sex,determinand,matrix,basis,value,unit,censoring,limit_detection,limit_quantification,uncertainty,unit_uncertainty,sample,subseries,source
 Canada,A6,Western Hudson Bay,2006,Rangifer tarandus,I,HG,KI,D,1.43,ug/g,,,,,,A12594,,Gamberg
 Canada,A6,Western Hudson Bay,2006,Rangifer tarandus,I,HG,KI,D,1.5,ug/g,,,,,,A12595,,Gamberg
 Canada,A6,Western Hudson Bay,2006,Rangifer tarandus,M,HG,KI,D,1.57,ug/g,,,,,,A12596,,Gamberg

--- a/data/example_external_data/AMAP_external_data_new_data_only_GRL_AllSpecies.csv
+++ b/data/example_external_data/AMAP_external_data_new_data_only_GRL_AllSpecies.csv
@@ -1,4 +1,4 @@
-﻿country,station_code,station_name,year,species,sex,determinand,matrix,basis,value,unit,qflag,limit_detection,limit_quantification,uncertainty,unit_uncertainty,sample,subseries,source
+﻿country,station_code,station_name,year,species,sex,determinand,matrix,basis,value,unit,censoring,limit_detection,limit_quantification,uncertainty,unit_uncertainty,sample,subseries,source
 Greenland,A90,Ittoqqortoormiit AMAP,1983,Ursus maritimus,M,HG,LI,W,4.41,mg/kg,,,,25,%,A20001,juvenile,Riget
 Greenland,A90,Ittoqqortoormiit AMAP,1983,Ursus maritimus,M,AGMEA,WO,,2,y,,,,,,A20001,juvenile,Riget
 Greenland,A90,Ittoqqortoormiit AMAP,1983,Ursus maritimus,M,N15D,MU,D,19.75,ppt,,,,,,A20001,juvenile,Riget

--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -668,8 +668,8 @@ water_web <- ctsm_web_initialise(
 ctsm_summary_table(
   assessments = list(
     Biota = biota_web, 
-    Sediment = sediment_web 
-    # Water = water_web
+    Sediment = sediment_web, 
+    Water = water_web
   ),
   determinandGroups = webGroups,
   path = file.path("output", "example_HELCOM")

--- a/example_HELCOM_data_adjustments.Rmd
+++ b/example_HELCOM_data_adjustments.Rmd
@@ -227,7 +227,7 @@ if (sum(water_data$data$.id) != 23) {
 water_data$data %>% 
   filter(.id) %>% 
   select(
-    country, year, determinand, value, qflag, limit_detection, 
+    country, year, determinand, value, censoring, limit_detection, 
     limit_quantification, uncertainty, unit_uncertainty
   ) %>% 
   as.data.frame() %>% 
@@ -742,7 +742,7 @@ wk_data <- mutate(
   determinand = "CORG", 
   value = Value,
   unit = "%", 
-  qflag = NA_character_,
+  censoring = NA_character_,
   method_analysis = NA_character_,
   limit_detection = NA_real_,
   limit_quantification = NA_real_, 
@@ -796,7 +796,7 @@ wk_CORG <- do.call(rbind, wk_CORG)
   
 wk_id <- c(
   "pargroup", "determinand", "basis", "unit",
-  "value", "qflag", "limit_detection", "limit_quantification", "uncertainty", 
+  "value", "censoring", "limit_detection", "limit_quantification", "uncertainty", 
   "unit_uncertainty", "alabo", "method_analysis", "smtyp", "qalink"
 )
 
@@ -933,7 +933,7 @@ The relative standard deviations is estimated using the same procedures as used 
 ```{r sed_uncrt2}
 out_relative <- wk %>% 
   filter(
-    is.na(.data$qflag), 
+    is.na(.data$censoring), 
     !is.na(alabo)
   ) %>% 
   group_by(.data$determinand, .data$alabo, .data$country) %>% 
@@ -1279,23 +1279,23 @@ xyplot(
 <br>
 
 
-#### Strange qflags
+#### Strange censoring values
 
-The following data from relevant stations (with data in the last six years) have qflag = ">", which is unusual. The German data appear to be well above the limits of detection, so the ">" has been removed. The Swedish data appear to be values below the limit of detection and have been replaced with qflag = "D".
+The following data from relevant stations (with data in the last six years) have censoring = ">", which is unusual. The German data appear to be well above the limits of detection, so the ">" has been removed. The Swedish data appear to be values below the limit of detection and have been replaced with censoring = "D".
 
-```{r bio_qflag1}
+```{r bio_censoring1}
 get_relevant_biota() %>%
-  filter(grepl(">", qflag)) %>% 
-  select(country, year, determinand, value, qflag, limit_detection, limit_quantification) %>% 
+  filter(grepl(">", censoring)) %>% 
+  select(country, year, determinand, value, censoring, limit_detection, limit_quantification) %>% 
   arrange(country, year, determinand) %>% 
   as.data.frame() %>% 
   DT::datatable(options = DT_options, rownames = FALSE)
 
 biota_data$data <- mutate(
   biota_data$data, 
-  .id = grepl(">", qflag), 
-  qflag = if_else(.id & country == "Germany", NA_character_, qflag),
-  qflag = if_else(.id & country == "Sweden", "D", qflag),
+  .id = grepl(">", censoring), 
+  censoring = if_else(.id & country == "Germany", NA_character_, censoring),
+  censoring = if_else(.id & country == "Sweden", "D", censoring),
   .id = NULL    
 )
 ```

--- a/functions/information_functions.R
+++ b/functions/information_functions.R
@@ -1936,7 +1936,7 @@ convert_units_workup <- function(units) {
 # Basis and matrix information and basis conversion ----
 
 convert.basis <- function(
-  conc, from, to, drywt, drywt.qflag, lipidwt = NA, lipidwt.qflag = NA, exclude) {
+  conc, from, to, drywt, drywt.censoring, lipidwt = NA, lipidwt.censoring = NA, exclude) {
 
   library(dplyr)
   
@@ -1944,7 +1944,7 @@ convert.basis <- function(
   # converts between wet, dry and lipid basis of measurement
 
   data <- data.frame(
-    conc, from, to, drywt, drywt.qflag, lipidwt, lipidwt.qflag, 
+    conc, from, to, drywt, drywt.censoring, lipidwt, lipidwt.censoring, 
     stringsAsFactors = FALSE
   )
   
@@ -1967,7 +1967,7 @@ convert.basis <- function(
   # ensure columns of data are of correct type
 
   data <- mutate_at(data, c("drywt", "lipidwt"), as.numeric)
-  data <- mutate_at(data, c("drywt.qflag", "lipidwt.qflag"), as.character)
+  data <- mutate_at(data, c("drywt.censoring", "lipidwt.censoring"), as.character)
   
   data$conc[!ok] <- with(data[!ok, ], {
 
@@ -1977,10 +1977,10 @@ convert.basis <- function(
       from == "L" ~ lipidwt
     )
     
-    from_qflag <- case_when(
+    from_censoring <- case_when(
       from == "W" ~ "", 
-      from == "D" ~ drywt.qflag, 
-      from == "L" ~ lipidwt.qflag
+      from == "D" ~ drywt.censoring, 
+      from == "L" ~ lipidwt.censoring
     )
 
     to_value <- case_when(
@@ -1989,16 +1989,16 @@ convert.basis <- function(
       to == "L" ~ lipidwt
     )
     
-    to_qflag <- case_when(
+    to_censoring <- case_when(
       to == "W" ~ "", 
-      to == "D" ~ drywt.qflag,
-      to == "L" ~ lipidwt.qflag
+      to == "D" ~ drywt.censoring,
+      to == "L" ~ lipidwt.censoring
     )
 
-    qflag_ok <- from_qflag %in% "" & to_qflag %in% ""
+    censoring_ok <- from_censoring %in% "" & to_censoring %in% ""
     
     conc <- case_when(
-      ! qflag_ok ~ NA_real_,
+      ! censoring_ok ~ NA_real_,
       TRUE ~ conc * from_value / to_value
     )
     conc


### PR DESCRIPTION
- qflag renamed as censoring throughout (originally was going to be renamed as less_than, but we could have greater thans as well)
- tested on five original data sets and Canadian mammal data
- all variables in external data sets have now been renamed to their agreed names