### PR TITLE
Issues 119, 141

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -498,31 +498,6 @@ biota_assessment$assessment <- local({
 })
 
 
-### tidy up ----
-
-# make timeSeries factor levels more interpretable
-
-biota_assessment$timeSeries <- biota_assessment$timeSeries %>% 
-  rownames_to_column(".rownames") %>% 
-  mutate(
-    .matrix = ctsm_get_info("matrix", matrix, "name"), 
-    .matrix = str_to_sentence(.matrix),
-    level6name = case_when(
-      level6element %in% "matrix" ~ .matrix,
-      level6element %in% "sex" ~ recode(level6name, "F" = "Female", "M" = "Male"),
-      TRUE ~ level6name
-    ),
-    .matrix = NULL,
-    level6element = recode(
-      level6element, 
-      matrix = "Tissue", 
-      sex = "Sex", 
-      "METOA" = "Chemical analysis"
-    )
-  ) %>% 
-  column_to_rownames(".rownames")
-
-
 # saveRDS(biota_assessment, file.path("RData", "biota assessment.rds"))
 
 

--- a/example_external_data.r
+++ b/example_external_data.r
@@ -158,7 +158,6 @@ biota_assessment$assessment <- ctsm.assessment(biota_assessment)
 #   library("tidyverse")
 # })  
 # 
-# 
 # biota_assessment$assessment <- ctsm.assessment(
 #   biota_assessment, 
 #   clusterID = wk.cluster
@@ -179,42 +178,6 @@ biota_assessment$assessment <- ctsm.assessment(biota_assessment)
 # refit with different numerical differencing arguments
 # biota_assessment$assessment[wk_check] <- 
 #   ctsm.assessment(biota_assessment, seriesID = wk_check, hess.d = 0.01, hess.r = 8)
-
-
-## tidy up ----
-
-# make timeSeries factor levels more interpretable
-
-biota_assessment$timeSeries <- biota_assessment$timeSeries %>% 
-  rownames_to_column(".rownames") %>% 
-  mutate(
-    .matrix = ctsm_get_info("matrix", matrix, "name") %>% 
-      str_to_sentence() %>% 
-      recode(
-        "Erythrocytes (red blood cells in vertebrates)" = "Red blood cells",
-        "Egg homogenate of yolk and albumin" = "Egg yolk & albumin"
-      ), 
-    level6name = case_when(
-      level6element %in% "matrix" ~ .matrix,
-      level6element %in% "sex" ~ recode(level6name, "F" = "Female", "M" = "Male"),
-      TRUE ~ level6name
-    ),
-    level7name = case_when(
-      level7element %in% "matrix" ~ .matrix,
-      level7element %in% "subseries" ~ gsub("_", " ", level7name),
-      TRUE ~ level7name
-    ),
-    .matrix = NULL,
-    level6element = recode(
-      level6element, 
-      matrix = "Tissue", 
-      sex = "Sex", 
-      "METOA" = "Chemical analysis"
-    ),
-    level7element = recode(level7element, matrix = "Tissue")
-  ) %>% 
-  column_to_rownames(".rownames")
-
 
 # saveRDS(biota_assessment, file.path("RData", "biota assessment.rds"))
 

--- a/example_simple_OSPAR.r
+++ b/example_simple_OSPAR.r
@@ -126,42 +126,6 @@ biota_assessment$assessment <- ctsm.assessment(biota_assessment)
 ctsm_check_convergence(biota_assessment$assessment)
 
 
-# tidy up 
-
-# make timeSeries factor levels more interpretable
-
-biota_assessment$timeSeries <- biota_assessment$timeSeries %>% 
-  rownames_to_column(".rownames") %>% 
-  mutate(
-    .matrix = ctsm_get_info("matrix", matrix, "name") %>% 
-      str_to_sentence() %>% 
-      recode(
-        "Erythrocytes (red blood cells in vertebrates)" = "Red blood cells",
-        "Egg homogenate of yolk and albumin" = "Egg yolk & albumin"
-      ), 
-    level6name = case_when(
-      level6element %in% "matrix" ~ .matrix,
-      level6element %in% "sex" ~ recode(level6name, "F" = "Female", "M" = "Male"),
-      TRUE ~ level6name
-    ),
-    level7name = case_when(
-      level7element %in% "matrix" ~ .matrix,
-      level7element %in% "subseries" ~ gsub("_", " ", level7name),
-      TRUE ~ level7name
-    ),
-    .matrix = NULL,
-    level6element = recode(
-      level6element, 
-      matrix = "Tissue", 
-      sex = "Sex", 
-      "METOA" = "Chemical analysis"
-    ),
-    level7element = recode(level7element, matrix = "Tissue")
-  ) %>% 
-  column_to_rownames(".rownames")
-
-
-
 # Summary files ----
 
 # web objects: these are a legacy from a Flash app for displaying results


### PR DESCRIPTION
- remove info$purpose dependencies in construction of timeSeries objects (issue 119)
- partial tidy up of legacy 'Flash' variables in timeSeries structure (issue 141)
- streamline example scripts by removing the ad-hoc manipulation of timeSeries component of assessment objects
- tested on all five original and Canadian mammal data