### PR TITLE
Issue 118 (purpose dependency)

### DIFF
--- a/example_external_data.r
+++ b/example_external_data.r
@@ -60,7 +60,7 @@ values_range_check_species(species, min_value, max_value)
 
 biota_data <- ctsm_read_data(
   compartment = "biota", 
-  purpose = "OSPAR",                               
+  # purpose = "OSPAR",                               
   contaminants = "AMAP_external_data_new_data_only_CAN_MarineMammals.csv", 
   stations = "AMAP_external_new_stations_only.csv", 
   path = file.path("data", "example_external_data"), 

--- a/example_simple_OSPAR.r
+++ b/example_simple_OSPAR.r
@@ -61,7 +61,7 @@ biota_data <- ctsm_read_data(
   QA = "quality_assurance.csv",
   path = file.path("data", "example_simple_OSPAR"), 
   extraction = "2022/01/11",
-  max_year = 2020L
+  max_year = 2020L  
 )  
 
 


### PR DESCRIPTION
- remove info$purpose dependency on filtering bivalve data collected in spawning season
- this is now controlled by info$bivalve_spawning_season with OSPAR and HELCOM defaults; otherwise defaults to NULL with no data being removed
- can be modified by user in control argument to ctsm_read_data
- tested on all five original data sets and canadian mammals data
- the latter example now works without having to specify info$purpose (provided no threshold values / assessment criteria are used)
- issue 118 now sorted