### PR TITLE
Issue 169: max_year

### DIFF
--- a/example_external_data.r
+++ b/example_external_data.r
@@ -65,7 +65,7 @@ biota_data <- ctsm_read_data(
   stations = "AMAP_external_new_stations_only.csv", 
   path = file.path("data", "example_external_data"), 
   extraction = "2022/01/11",
-  max_year = 2020L, 
+  # max_year = 2020L, 
   data_format = "external", 
   control = list(region_id = "AMAP_region")
 )  


### PR DESCRIPTION
- max_year no longer needs to be specified in call to ctsm_read_data
- default is to take the maximum year in the data
- improved error and warning messages
- data deletion of years greater than max_year moved to tidy_contaminants where there will be quite a bit of filtering when new ICES extractions come on line
- tested on all data sets