### PR TITLE
Issue 168 extraction date

### DIFF
--- a/example_external_data.r
+++ b/example_external_data.r
@@ -64,7 +64,7 @@ biota_data <- ctsm_read_data(
   contaminants = "AMAP_external_data_new_data_only_CAN_MarineMammals.csv", 
   stations = "AMAP_external_new_stations_only.csv", 
   path = file.path("data", "example_external_data"), 
-  extraction = "2022/01/11",
+  # extraction = "2022/01/11",
   # max_year = 2020L, 
   data_format = "external", 
   control = list(region_id = "AMAP_region")

--- a/functions/graphics_functions.R
+++ b/functions/graphics_functions.R
@@ -310,8 +310,10 @@ ctsm.web.getKey <- function(info, auxiliary.plot = FALSE, html = FALSE) {
     out$units <- paste(out$units, extra.text, sep = sep.html)
   }
   
-  
-  out$extraction <- paste("Data extraction: ", info$extraction, sep = "")
+  out$extraction <- "Data extraction:"
+  if (!is.null(info$extraction)) {
+    out$extraction <- paste(out$extraction, format(info$extraction, "%d %B %Y"))
+  }
 
   out
 }

--- a/functions/import_functions.R
+++ b/functions/import_functions.R
@@ -10,12 +10,14 @@ ctsm_read_data <- function(
   stations, 
   QA, 
   path = ".", 
-  extraction, 
+  extraction = NULL, 
   max_year = NULL, 
   control = list(), 
   data_format = c("ICES_old", "ICES_new", "external")) {
 
   # import_functions.R
+  # dependencies lubridate
+  
   # reads in data from an ICES extraction or from an external data file
   
   
@@ -37,34 +39,36 @@ ctsm_read_data <- function(
     }
   }    
     
+  if (!is.null(extraction)) {
+    if (length(extraction) > 1 | !is.character(extraction)) {
+      stop(
+        "extraction must be a single character string of the form ymd: e.g. \"",
+        lubridate::today(), ""
+      )
+    }
+  }  
+  
+  
+  # turn extraction into date object
 
-  # sort out extraction date
+  if (!is.null(extraction)) {
+    extraction <- suppressWarnings(lubridate::ymd(extraction))
+    if (is.na(extraction)) {
+      stop(
+        "extraction not recognised: it must be a valid date of the form ", 
+        "ymd: e.g. \"", lubridate::today(), "\""
+      )
+    }  
+  }  
+
     
-  if (length(extraction) > 1) {
-    stop("extraction must be a single date")
-  }
-  extraction <- as.POSIXlt(extraction)
-  
-  extraction_year <- as.numeric(format(extraction, "%Y"))
-  extraction_month <- as.numeric(format(extraction, "%m"))
-  
-  if (!is.null(max_year) && extraction_year < max_year) {
-    stop("extraction predates some monitoring data")
-  }
-  
-  extraction_text <- format(extraction, "%d %B %Y")
-  if (substring(extraction_text, 1, 1) == "0") { 
-    extraction_text <- substring(extraction_text, 2)
-  }
-  
-  
   # set up control (info) structure 
   # some of this should probably go in ctsm_create_timeSeries
     
   info <- list(
     compartment = compartment, 
     purpose = purpose, 
-    extraction = extraction_text,
+    extraction = extraction,
     data_format = data_format, 
     max_year = max_year
   )


### PR DESCRIPTION
- now an optional argument (default NULL)
- must be supplied in ymd format (exact form not crucial, as long as lubridate can identify it)
- suitable error message if date not recognised
- now stored as date
- graphics routines updated so it prints correctly
- tested on Canadian mammals data