### PR TITLE
#190 #154 Oddity files and factors

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -59,7 +59,7 @@ biota_data <- ctsm_read_data(
   contaminants = "biota_data.csv", 
   stations = "station_dictionary.csv", 
   QA = "quality_assurance.csv",
-  path = file.path("data", "example_HELCOM"), 
+  data_path = file.path("data", "example_HELCOM"), 
   extraction = "2022/10/06",
   max_year = 2021L
 )  
@@ -72,8 +72,9 @@ biota_data <- ctsm_read_data(
 sediment_data <- ctsm_read_data(
   compartment = "sediment",
   purpose = "HELCOM",
-  contaminants = file.path("data", "example_HELCOM_new_format", "sediment_data.csv"),
-  stations = file.path("data", "example_HELCOM", "station_dictionary.csv"),
+  contaminants = file.path("example_HELCOM_new_format", "sediment_data.csv"),
+  stations = file.path("example_HELCOM", "station_dictionary.csv"),
+  data_path = "data",
   extraction = "2022/10/06",
   max_year = 2021L,
   data_format = "ICES_new"
@@ -87,8 +88,9 @@ sediment_data <- ctsm_read_data(
 water_data <- ctsm_read_data(
   compartment = "water", 
   purpose = "HELCOM",                               
-  contaminants = file.path("data", "example_HELCOM_new_format", "water_data.csv"), 
-  stations = file.path("data", "example_HELCOM", "station_dictionary.csv"), 
+  contaminants = file.path("example_HELCOM_new_format", "water_data.csv"), 
+  stations = file.path("example_HELCOM", "station_dictionary.csv"), 
+  data_path = "data", 
   extraction = "2022/10/06",
   max_year = 2021L, 
   data_format = "ICES_new"

--- a/example_external_data.r
+++ b/example_external_data.r
@@ -52,7 +52,7 @@ biota_data <- ctsm_read_data(
   # purpose = "OSPAR",                               
   contaminants = "AMAP_external_data_new_data_only_CAN_MarineMammals.csv", 
   stations = "AMAP_external_new_stations_only.csv", 
-  path = file.path("data", "example_external_data"), 
+  data_path = file.path("data", "example_external_data"), 
   # extraction = "2022/01/11",
   # max_year = 2020L, 
   data_format = "external", 

--- a/example_simple_OSPAR.r
+++ b/example_simple_OSPAR.r
@@ -49,7 +49,7 @@ biota_data <- ctsm_read_data(
   contaminants = "test_data.csv", 
   stations = "station_dictionary.csv", 
   QA = "quality_assurance.csv",
-  path = file.path("data", "example_simple_OSPAR"), 
+  data_path = file.path("data", "example_simple_OSPAR"), 
   extraction = "2022/01/11",
   max_year = 2020L  
 )  


### PR DESCRIPTION
- tidied up checking routines associated with oddity files; these are now simplified, have cleary defined purposes, and pick up relevant structures in the current environment rather than looking in the top level calling environment
- oddity_path is now specified in ctsm_read_data (rather than in ctsm_tidy_data) and carried through all subsequent code using the info object; renamed path argument as data_path for clarity
- all factor inputs and output to ctsm_create_timeSeries have now been replaced by characters
- tested on five original data sets and canadian mammals