### PR TITLE
Issue 121 Thresholds simplification

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -282,7 +282,7 @@ water_timeSeries <- ctsm_create_timeSeries(
 sediment_assessment <- ctsm_assessment(
   sediment_timeSeries, 
   AC = "EQS",
-  parallel = FALSE
+  parallel = TRUE
 )
 
 
@@ -317,8 +317,8 @@ wk_group <- ctsm_get_info(
 biota_assessment <- ctsm_assessment(
   biota_timeSeries, 
   AC = c("BAC", "EAC", "EQS", "MPC"), 
-  subset = determinand %in% wk_determinands[wk_group == "Metals"], 
-  parallel = FALSE
+  subset = determinand %in% wk_determinands[wk_group == "Metals"],
+  parallel = TRUE
 )
 
 wk_organics <- c(
@@ -329,7 +329,7 @@ wk_organics <- c(
 biota_assessment <- ctsm_update_assessment(
   biota_assessment, 
   subset = determinand %in% wk_determinands[wk_group %in% wk_organics], 
-  parallel = FALSE
+  parallel = TRUE
 )
 
 biota_assessment <- ctsm_update_assessment(
@@ -380,7 +380,8 @@ ctsm_check_convergence(biota_assessment$assessment[wk_id])
 
 water_assessment <- ctsm_assessment(
   water_timeSeries, 
-  AC = "EQS"
+  AC = "EQS", 
+  parallel = TRUE
 )
 
 

--- a/example_simple_OSPAR.r
+++ b/example_simple_OSPAR.r
@@ -7,7 +7,6 @@
 # Setup ----
 
 # Sources functions (folder R) and reference tables (folder information)
-# Only those functions needed for this example are sourced here
 # The functions and reference tables folders are assumed to be in the current
 # R project folder
 
@@ -22,7 +21,8 @@ devtools::load_all()
 # There are three input data sets: 
 # - the contaminant data
 # - the station dictionary
-# - the quality assurance data (more accurately called a chemical methods file)
+# - the quality assurance data (more accurately called a chemical methods file);
+#     this will disappear before release
 
 biota_data <- ctsm_read_data(
   compartment = "biota", 
@@ -33,7 +33,8 @@ biota_data <- ctsm_read_data(
   data_path = file.path("data", "example_simple_OSPAR"),
   info_files = list(
     determinand = "determinand_simple_OSPAR.csv", 
-    thresholds = "thresholds_biota_simple_OSPAR.csv"),
+    thresholds = "thresholds_biota_simple_OSPAR.csv"
+  ),
   info_path = "information", 
   extraction = "2022/01/11",
   max_year = 2020L  
@@ -90,6 +91,19 @@ biota_assessment <- ctsm_assessment(
   biota_timeSeries, 
   AC = c("BAC", "EAC", "EQS", "HQS")
 )
+
+
+# can supply own function for calculating AC - in the example below it
+# will generate exactly the same results
+
+# my_get_AC <- get_AC$biota
+# 
+# biota_assessment <- ctsm_assessment(
+#   biota_timeSeries, 
+#   AC = c("BAC", "EAC", "EQS", "HQS"), 
+#   get_AC_fn = my_get_AC
+# )
+
 
 
 # check convergence - no errors this time

--- a/vignettes/example_HELCOM.Rmd.orig
+++ b/vignettes/example_HELCOM.Rmd.orig
@@ -282,7 +282,6 @@ Main runs
 sediment_assessment <- ctsm_assessment(
   sediment_timeSeries,
   AC = "EQS",
-  get_assessment_criteria = get.AC.HELCOM,
   parallel = TRUE
 )
 ```

--- a/vignettes/example_external_data.Rmd.orig
+++ b/vignettes/example_external_data.Rmd.orig
@@ -79,7 +79,11 @@ biota_assessment <- ctsm_assessment(biota_timeSeries)
 Use the code below if it takes a long time to run
 
 ```
-biota_assessment <- ctsm_assessment(biota_timeSeries, parallel = TRUE)
+biota_assessment <- ctsm_assessment(
+  biota_timeSeries,
+  AC = c("NRC", "LRC", "MRC", "HRC")
+  parallel = TRUE
+)
 ```
 
 ## Check convergence
@@ -101,7 +105,12 @@ if (!dir.exists(summary.dir)) {
 
 ctsm_summary_table(
   biota_assessment,
-  output_dir = summary.dir
+  output_dir = summary.dir,
+    classColour = list(
+    below = c("NRC" = "blue", "LRC" = "green", "MRC" = "orange", "HRC" = "darkorange"),
+    above = c("NRC" = "red", "LRC" = "red", "MRC" = "red", "HRC" = "red"),
+    none = "black"
+  )
 )
 ```
 

--- a/vignettes/example_simple_OSPAR.Rmd.orig
+++ b/vignettes/example_simple_OSPAR.Rmd.orig
@@ -25,7 +25,8 @@ library(harsat)
 There are three input data sets: 
 - the contaminant data
 - the station dictionary
-- the quality assurance data (more accurately called a chemical methods file)
+- the quality assurance data (more accurately called a chemical methods file); 
+note that this will disappear before the first release of the harsat package
 
 Load the R package `here`, because we use the working directory to find
 the data files. If you use your own data files, you will need to point to
@@ -45,7 +46,10 @@ biota_data <- ctsm_read_data(
   stations = "station_dictionary.csv", 
   QA = "quality_assurance.csv",
   data_path = file.path(working.directory, "data", "example_simple_OSPAR"),
-  info_files = list(determinand = "determinand_simple_OSPAR.csv"),
+  info_files = list(
+    determinand = "determinand_simple_OSPAR.csv", 
+    thresholds = "thresholds_biota_simple_OSPAR.csv"
+  ),
   info_path = file.path(working.directory, "information"), 
   extraction = "2022/01/11",
   max_year = 2020L  
@@ -105,8 +109,7 @@ Do the statistical analysis
 ```{r ospar-assessment}
 biota_assessment <- ctsm_assessment(
   biota_timeSeries, 
-  AC = c("BAC", "EAC", "EQS", "HQS"), 
-  get_assessment_criteria = get.AC.OSPAR
+  AC = c("BAC", "EAC", "EQS", "HQS")
 )
 ```
 


### PR DESCRIPTION
- default functions get_AC$biota, get_AC$sediment, get_AC$water now accessed directly (without get or do.call)
- these functions can be replaced by a user defined function using argument get_AC_fn
- tested on all five test data sets, in parallel and in series
- vignettes updated accordingly

Still to do before release:
- create OSPAR thresholds tables (currently only available for simple example with limited determinands)
- extend sediment code to deal with regional thresholds

Still to do at some point:
- the three default get_AC functions share a lot of code and can be streamlined
- a lot of better error trapping is required
- unnamed functions could be named and called to simplify the reading of the code

I will update the issues to reflect these