### PR TITLE
Issue 215 failure when drywt not specified as auxiliary variable

### DIFF
--- a/R/information_functions.R
+++ b/R/information_functions.R
@@ -1985,7 +1985,7 @@ ctsm_convert_basis <- function(
   # ensure variables are stored as characters (rather than factors)
   
   var_id <- c("from", "to", "drywt_censoring", "lipidwt_censoring")
-  data <- dplyr::mutate(data, dplyr::across(all_of(var_id), as.character))
+  data <- dplyr::mutate(data, across(all_of(var_id), as.character))
 
   
   # check arguments have admissible values


### PR DESCRIPTION
- bug fixed
- failure occurred when converting data to the target basis
- solved by creating empty columns to allow basis conversion if drywt or lipidwt are not specified in determinand file
- tested on Simon's data set (where the failure occured) and on existing examples
- robust, but inelegant solution; however, there is more work to do with auxiliary variables (see issue #81 - future enhancement), so things can be improved then; suspect it would be best to automatically create drywt and lipidwt variables when contaminants are being investigated (but not when only biological effects are present)

Also made some dplyr calls explicit as I went along (part of an ongoing process)