### PR TITLE
Matching stations to data from webservice extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ RData/
 /doc/
 /Meta/
 docs
+.Rbuildignore

--- a/example_OSPAR.r
+++ b/example_OSPAR.r
@@ -25,14 +25,17 @@ biota_data <- read_data(
   compartment = "biota", 
   purpose = "OSPAR",                               
   contaminants = "ICES_DOME_XHAT_biota_data_2023071211435199.txt",
+  # contaminants = "ICES_DOME_XHAT_sediment_data_2023071218201042.txt",
+  # contaminants = "ICES_DOME_XHAT_water_data_2023071218223355.txt",
   stations = "ICES_DOME_XHAT_station_data_2023071211380640.txt", 
   data_dir = file.path("data", "example_OSPAR"),
   info_files = list(
-    determinand = "determinand_simple_OSPAR.csv", 
+    determinand = "determinand_simple_OSPAR.csv",
     thresholds = "thresholds_biota_simple_OSPAR.csv"
   ),
   info_dir = "information"
 )  
+
 
 
 # Prepare data for next stage ----


### PR DESCRIPTION
Progress:
- (mostly) working with biota and sediment.
- updated the AMAP matching options following a conversation with Simon
- turned (most of) the matching options into a control list that can be adjusted in the read_data routine - this allows more flexibility for custom users and, more importantly, makes it easier to update if extraction requirements change for any of the conventions; need to finish this off but ran out of time today
- future proofed to allow for biological effects in sediment and water

Still need to:
- get working for water (something to do with filtration breaks down)
- check all contaminant pargroups are included (have added pharmaceuticals this time round)
- fix bug with replaced_by and grouping stations, when these don't have the same datatype as their child station (some NL biota stations have been grouped, but only the sediment stations should have been)

Tested that existing example routines still work