### PR TITLE
Remove tidyverse from package internals

### DIFF
--- a/R/assessment_functions.R
+++ b/R/assessment_functions.R
@@ -182,7 +182,6 @@ assessment_engine <- function(ctsm.ob, series_id, parallel = FALSE, ...) {
       cluster_id, 
       {
         library("lme4")
-        library("tidyverse")
       }
     )  
 

--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -1636,9 +1636,7 @@ ctsm_read_QA <- function(file, path, purpose) {
 ctsm_tidy_data <- function(ctsm_obj) {
   
   # import_functions.R
-  
-  library(tidyverse)
-  
+    
   info <- ctsm_obj$info
   data <- ctsm_obj$data
   stations <- ctsm_obj$stations
@@ -2113,10 +2111,6 @@ ctsm_create_timeSeries <- function(
   get_basis = get_basis_default,
   normalise = FALSE, 
   normalise.control = list()) {
-
-  # import_functions.R
-  
-  library(tidyverse)
 
   # arguments
   

--- a/man/fragments/example_HELCOM_data_adjustments.Rmd
+++ b/man/fragments/example_HELCOM_data_adjustments.Rmd
@@ -9,10 +9,12 @@ vignette: >
 
 ## Data adjustments: water
 
-We'll use the `lattice` function to plot some of the data so we can see it as we go.
+We'll use the `lattice` package
+to plot some of the data so we can see it as we go. Tables 
+will be made dynamic using progressive enhancement through
+the external JavaScript package [DataTables](https://datatables.net).
 
-```{r helcom-data-adjust-tables}
-library(tidyverse)
+```{r helcom-data-adjust-datatables}
 library(lattice)
 ```
 

--- a/vignettes/example_HELCOM.Rmd
+++ b/vignettes/example_HELCOM.Rmd
@@ -126,7 +126,10 @@ info_TEQ <- c(
 
 ## Data adjustments: water
 
-We'll use the `lattice` function to plot some of the data so we can see it as we go.
+We'll use the `lattice` package
+to plot some of the data so we can see it as we go. Tables 
+will be made dynamic using progressive enhancement through
+the external JavaScript package [DataTables](https://datatables.net).
 
 
 ```r


### PR DESCRIPTION
See #202

## Testing Notes

`tidyverse` has gone from package internals. Everything should still work.

## Technical Notes

1. We remove some `tidyverse` imports from package sources which are now redundant (and not best practice)
2. The vignettes can still use `tidyverse`, as they're outlines for a user
3. A few cleanups of datatables references were added because they slipped through #233