### PR TITLE
Fix use of check_convergence()

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -281,7 +281,7 @@ sediment_assessment <- run_assessment(
 
 ### check convergence ----
 
-check_convergence(sediment_assessment)
+check_convergence_lmm(sediment_assessment)
 
 
 
@@ -381,7 +381,7 @@ water_assessment <- run_assessment(
 
 ### check convergence ----
 
-check_convergence(water_assessment)
+check_convergence_lmm(water_assessment)
 
 
 # refit a couple of time series where the fixed effects are on their bounds
@@ -389,7 +389,7 @@ check_convergence(water_assessment)
 # "5190 CD Yes" - fixed effects on bounds
 # "5192 CD Yes" - fixed effects on bounds
 
-wk_id <- check_convergence(water_assessment, save_result = TRUE)
+wk_id <- check_convergence_lmm(water_assessment, save_result = TRUE)
 
 water_assessment <- update_assessment(
   water_assessment, 
@@ -400,7 +400,7 @@ water_assessment <- update_assessment(
 
 # check that refitted timeseries have converged
 
-check_convergence(water_assessment)
+check_convergence_lmm(water_assessment)
 
 
 

--- a/example_external_original.R
+++ b/example_external_original.R
@@ -107,7 +107,7 @@ biota_assessment <- ctsm_assessment(
 
 ## check convergence ----
 
-(wk_check <- check_convergence(biota_assessment$assessment))
+(wk_check <- check_convergence_lmm(biota_assessment$assessment))
 
 # this time series has missing standard errors   
 # "3371 HG Mytilus edulis SB Not_applicable"                       

--- a/vignettes/harsat.Rmd
+++ b/vignettes/harsat.Rmd
@@ -296,8 +296,8 @@ We can then check that everything is converged.
 
 
 ```r
-check_convergence(biota_assessment$assessment)
-#> Error in check_convergence(biota_assessment$assessment): could not find function "check_convergence"
+check_convergence_lmm(biota_assessment$assessment)
+#> [1] 0
 ```
 
 ## Reporting

--- a/vignettes/harsat.Rmd.orig
+++ b/vignettes/harsat.Rmd.orig
@@ -172,7 +172,7 @@ There are various little warnings: these ones are nothing to worry about.
 We can then check that everything is converged.
 
 ```{r getting-started-convergence}
-check_convergence(biota_assessment$assessment)
+check_convergence_lmm(biota_assessment$assessment)
 ```
 
 ## Reporting


### PR DESCRIPTION
Resolves #236

## Testing Notes

Vignettes and the harsat.Rmd should no longer contain errors

## Technical Notes

Rename calls to check_convergence() to check_convergence_lmm()