### PR TITLE
A small patch to remove the heading comments

### DIFF
--- a/vignettes/file-management.Rmd
+++ b/vignettes/file-management.Rmd
@@ -145,11 +145,10 @@ biota_data <- read_data(
 
 There are a few important things to see here: 
 
-## Would like to encourage file.path which is platform independent ##
+1. Note the use of `file.path()` here to make portable pathnames. Of course,
+   each user can use whatever filename pattern works best for them. 
 
-## Think we should drop this - see comments ##
-
-2. The `info_path` parameter is strictly a *vector*, not a single string. 
+2. The `info_path` parameter can be a *vector* as well as a single string. 
    `harsat` will actually search through every directory in this vector,
    looking for files like `determinand.csv`. If the file is found in your 
    local analysis directory, it gets read and used. If not, we may try


### PR DESCRIPTION
Note that comments crept in as full headers. This removes them.

## Testing Notes

None -- this is wholly documentation

## Technical Notes

The core issue -- whether or not the path is a vector -- I have hedged on slightly. We should allow a scalar value to be used, and automagically make it into a vector (aka search path) if needed. That allows complete flexibility while remaining compatible with current practice -- apart from the odd filename suffixes per purpose field.