### PR TITLE
Fix the broken vignette links

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -17,6 +17,6 @@ navbar:
     - text: External data
       href: articles/example_external_data.html
     - text: Simple OSPAR
-      href: articles/example_simple_ospar.html
+      href: articles/example_simple_OSPAR.html
     - text: HELCOM
-      href: articles/example_helcom.html
+      href: articles/example_HELCOM.html


### PR DESCRIPTION
## Testing Notes

The dropdown links in the Articles tab should work

## Technical Notes

Simple renaming.