### PR TITLE
Remove dependency on DT

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,8 +34,7 @@ Imports:
   parallel,
   pbapply,
   MASS,
-  mvtnorm,
-  DT
+  mvtnorm
 Suggests: 
     knitr,
     rmarkdown,

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ The following R packages need to be installed to run the HELCOM example:
 
 *	rmarkdown
 *	htmlwidgets
-*	DT
 
 File -> New Project in RStudio to create a new project. File -> New Project -> Version Control -> GIT -> https://github.com/osparcomm/HARSAT to clone from repository.
 


### PR DESCRIPTION
## Testing Notes

The HELCOM vignette should still render, but we don't use the R package DT.

## Technical Notes

Because we precompile, we generate HTML tables using `knitr::kable`, and then use vanilla JavaScript to run progressive enhancement. So we still use the JS DataTables package, but not through an installed R `DT` package, because that really doesn't make pre-compilation valid.