### PR TITLE
OSPAR 2022 determinand ref table

### DIFF
--- a/information/determinand_OSPAR_2022.csv
+++ b/information/determinand_OSPAR_2022.csv
@@ -1,166 +1,166 @@
 ﻿determinand,common_name,pargroup,biota_group,sediment_group,water_group,biota_assess,sediment_assess,water_assess,biota_unit,sediment_unit,water_unit,biota_auxiliary,sediment_auxiliary,water_auxiliary,biota_sd_constant,biota_sd_variable,sediment_sd_constant,sediment_sd_variable,water_sd_constant,water_sd_variable,distribution,good_status
-AG,Silver,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,1.633333,0.15,,,,,lognormal,low
+AG,Silver,I-MET,Metals,Metals,Metals,TRUE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,1.633333,0.15,,,,,lognormal,low
 AL,Aluminium,I-MET,Metals,Auxiliary,Metals,FALSE,FALSE,FALSE,ug/kg,%,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,,,0.000667,0.125644,,,lognormal,low
-AS,Arsenic,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,3.133333,0.075245,0.1,0.10025,,,lognormal,low
+AS,Arsenic,I-MET,Metals,Metals,Metals,TRUE,TRUE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,3.133333,0.075245,0.1,0.10025,,,lognormal,low
 BA,Barium,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,,,,,,,lognormal,low
-CD,Cadmium,I-MET,Metals,Metals,Metals,TRUE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,0.526867,0.07022,0.005,0.109988,0.002333,0.121905,lognormal,low
-CO,Cobalt,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,0.3,0.125,,,,,lognormal,low
-CR,Chromium,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,3,0.145626,0.216667,0.08998,,,lognormal,low
-CU,Copper,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,2,0.076316,0.158333,0.090478,0.025167,0.072003,lognormal,low
+CD,Cadmium,I-MET,Metals,Metals,Metals,TRUE,TRUE,TRUE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,0.526867,0.07022,0.005,0.109988,0.002333,0.121905,lognormal,low
+CO,Cobalt,I-MET,Metals,Metals,Metals,TRUE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,0.3,0.125,,,,,lognormal,low
+CR,Chromium,I-MET,Metals,Metals,Metals,TRUE,TRUE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,3,0.145626,0.216667,0.08998,,,lognormal,low
+CU,Copper,I-MET,Metals,Metals,Metals,TRUE,TRUE,TRUE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,2,0.076316,0.158333,0.090478,0.025167,0.072003,lognormal,low
 FE,Iron,I-MET,Metals,Auxiliary,Metals,FALSE,FALSE,FALSE,ug/kg,%,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,,,,,,,lognormal,low
-HG,Mercury,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,0.541,0.087966,0.002167,0.100382,,,lognormal,low
+HG,Mercury,I-MET,Metals,Metals,Metals,TRUE,TRUE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,0.541,0.087966,0.002167,0.100382,,,lognormal,low
 LI,Lithium,I-MET,Metals,Auxiliary,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,,,0.033333,0.148842,,,lognormal,low
 MN,Manganese,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,,,,,,,lognormal,low
-NI,Nickel,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,3.333333,0.146991,0.15,0.084189,0.012167,0.061064,lognormal,low
-PB,Lead,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,2.333333,0.10368,0.283333,0.090517,0.0115,0.08951,lognormal,low
-SE,Selenium,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,2.984833,0.082638,,,,,lognormal,low
-SN,Tin,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,3.333333,0.25,,,,,lognormal,low
+NI,Nickel,I-MET,Metals,Metals,Metals,TRUE,TRUE,TRUE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,3.333333,0.146991,0.15,0.084189,0.012167,0.061064,lognormal,low
+PB,Lead,I-MET,Metals,Metals,Metals,TRUE,TRUE,TRUE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,2.333333,0.10368,0.283333,0.090517,0.0115,0.08951,lognormal,low
+SE,Selenium,I-MET,Metals,Metals,Metals,TRUE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,2.984833,0.082638,,,,,lognormal,low
+SN,Tin,I-MET,Metals,Metals,Metals,TRUE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,3.333333,0.25,,,,,lognormal,low
 SR,Strontium,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,,,,,,,lognormal,low
 V,Vanadium,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,,,,,,,lognormal,low
-ZN,Zinc,I-MET,Metals,Metals,Metals,FALSE,FALSE,FALSE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,50,0.073982,0.258333,0.084814,0.028667,0.082049,lognormal,low
-ACNE,Acenaphthene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.056667,0.253,0.4,0.186207,0.14445,0.15,lognormal,low
-ACNLE,Acenaphthylene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.101667,0.276779,0.333333,0.271315,0.116667,0.12925,lognormal,low
-ANT,Anthracene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.066667,0.22,0.333333,0.170818,0.14445,0.1085,lognormal,low
-BAA,Benzo[a]anthracene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.093333,0.188502,0.333333,0.13,0.14445,0.118056,lognormal,low
-BAP,Benzo[a]pyrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.053333,0.211934,0.333333,0.15,0.066667,0.14,lognormal,low
+ZN,Zinc,I-MET,Metals,Metals,Metals,TRUE,TRUE,TRUE,ug/kg,mg/kg,ug/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%~LI,,50,0.073982,0.258333,0.084814,0.028667,0.082049,lognormal,low
+ACNE,Acenaphthene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.056667,0.253,0.4,0.186207,0.14445,0.15,lognormal,low
+ACNLE,Acenaphthylene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.101667,0.276779,0.333333,0.271315,0.116667,0.12925,lognormal,low
+ANT,Anthracene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.066667,0.22,0.333333,0.170818,0.14445,0.1085,lognormal,low
+BAA,Benzo[a]anthracene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.093333,0.188502,0.333333,0.13,0.14445,0.118056,lognormal,low
+BAP,Benzo[a]pyrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.053333,0.211934,0.333333,0.15,0.066667,0.14,lognormal,low
 BBA,Benz[b]anthtacene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 BBF,Benzo[b]fluoranthene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 BBJF,"Benzo[b,j]fluoranthene",O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 BBJKF,"Benzo[b,j,k]fluoranthene",O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-BBKF,"Benzo[b,k]fluoranthene",O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.14,0.135946,0.666667,0.15,0.455567,0.27,lognormal,low
-BEP,Benzo[e]pyrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.101406,0.466667,0.079715,0.033667,0.127929,lognormal,low
-BGHIP,"Benzo[g,h,i]perylene",O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.056667,0.21,0.333333,0.15,0.055567,0.115385,lognormal,low
+BBKF,"Benzo[b,k]fluoranthene",O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.14,0.135946,0.666667,0.15,0.455567,0.27,lognormal,low
+BEP,Benzo[e]pyrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.101406,0.466667,0.079715,0.033667,0.127929,lognormal,low
+BGHIP,"Benzo[g,h,i]perylene",O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.056667,0.21,0.333333,0.15,0.055567,0.115385,lognormal,low
 BJKF,"Benzo[j,k]fluoranthene",O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 BKF,Benzo[k]fluoranthene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CHR,Chrysene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.082917,0.13996,0.666667,0.122391,0.127783,0.136964,lognormal,low
+CHR,Chrysene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.082917,0.13996,0.666667,0.122391,0.127783,0.136964,lognormal,low
 CHRTR,Chrysene / Triphenylene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-DBAHA,Dibenz[ah]anthracene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.045,0.230625,0.333333,0.253296,0.161117,0.1125,lognormal,low
-DBT,Dibenzothiophene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.1,0.235417,0.166667,0.1,0.00011,0.192,lognormal,low
-DBTC1,C1 Dibenzothiophene,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.25,0.104937,0.066667,0.093867,,,lognormal,low
-DBTC2,C2 Dibenzothiophene,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.338333,0.107267,0.128333,0.128289,,,lognormal,low
-DBTC3,C3 Dibenzothiophenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.485,0.107088,0.083333,0.091049,,,lognormal,low
-FLE,Fluorene ,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.08,0.21,0.433333,0.187868,0.127783,0.134182,lognormal,low
-FLU,Fluoranthene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.12296,0.333333,0.087395,0.088883,0.128833,lognormal,low
-ICDP,Indeno[123-cd]pyrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.063333,0.260325,0.333333,0.114842,0.1,0.15,lognormal,low
-NAP,Naphthalene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.242032,0.486667,0.140506,0.161117,0.175682,lognormal,low
+DBAHA,Dibenz[ah]anthracene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.045,0.230625,0.333333,0.253296,0.161117,0.1125,lognormal,low
+DBT,Dibenzothiophene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.1,0.235417,0.166667,0.1,0.00011,0.192,lognormal,low
+DBTC1,C1 Dibenzothiophene,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.25,0.104937,0.066667,0.093867,,,lognormal,low
+DBTC2,C2 Dibenzothiophene,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.338333,0.107267,0.128333,0.128289,,,lognormal,low
+DBTC3,C3 Dibenzothiophenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.485,0.107088,0.083333,0.091049,,,lognormal,low
+FLE,Fluorene ,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.08,0.21,0.433333,0.187868,0.127783,0.134182,lognormal,low
+FLU,Fluoranthene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.12296,0.333333,0.087395,0.088883,0.128833,lognormal,low
+ICDP,Indeno[123-cd]pyrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.063333,0.260325,0.333333,0.114842,0.1,0.15,lognormal,low
+NAP,Naphthalene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.242032,0.486667,0.140506,0.161117,0.175682,lognormal,low
 NAP1M,1-Methylnapthalene,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 NAP2M,2-Methylnaphthalene,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-NAPC1,C1 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.366667,0.21875,0.446667,0.103584,,,lognormal,low
-NAPC2,C2 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.120714,0.52,0.072425,,,lognormal,low
-NAPC3,C3 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.186667,0.134487,0.083333,0.089862,,,lognormal,low
-NAPC4,C4 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.056667,0.117742,0.033333,0.10842,,,lognormal,low
-PA,Phenanthrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.132083,0.14679,1,0.118578,0.222233,0.1095,lognormal,low
+NAPC1,C1 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.366667,0.21875,0.446667,0.103584,,,lognormal,low
+NAPC2,C2 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.120714,0.52,0.072425,,,lognormal,low
+NAPC3,C3 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.186667,0.134487,0.083333,0.089862,,,lognormal,low
+NAPC4,C4 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.056667,0.117742,0.033333,0.10842,,,lognormal,low
+PA,Phenanthrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.132083,0.14679,1,0.118578,0.222233,0.1095,lognormal,low
 PABC,Benzo[c]phenanthrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-PAC1,C1 Phenanthrenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.182622,0.38,0.066608,,,lognormal,low
-PAC2,C2 Phenanthrenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.066667,0.153048,0.111667,0.07926,,,lognormal,low
-PAC3,C3 Phenanthrenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.182622,0.385,0.083324,,,lognormal,low
+PAC1,C1 Phenanthrenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.182622,0.38,0.066608,,,lognormal,low
+PAC2,C2 Phenanthrenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.066667,0.153048,0.111667,0.07926,,,lognormal,low
+PAC3,C3 Phenanthrenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.182622,0.385,0.083324,,,lognormal,low
 PAM1,1-methylphenanthrene,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-PER,Perylene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.15,0.22255,0.138333,0.1,0.017217,0.125,lognormal,low
-PYR,Pyrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.1275,0.5,0.090558,0.14445,0.099621,lognormal,low
+PER,Perylene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.15,0.22255,0.138333,0.1,0.017217,0.125,lognormal,low
+PYR,Pyrene,O-PAH,PAH_parent,PAH_parent,PAH_parent,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.166667,0.1275,0.5,0.090558,0.14445,0.099621,lognormal,low
 SNAPC,Sum C1-3 Naphthalenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 SPAC,Sum C1-3 Phenanthrenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 SDBTC,Sum C1-3 Dibenzothiophenes,O-PAH,PAH_alkylated,PAH_alkylated,PAH_alkylated,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 TRI,Triphenylene,O-PAH,PAH_parent,PAH_parent,PAH_parent,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CB28,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.03,0.17,0.022667,0.169108,0,0.15,lognormal,low
+CB28,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.03,0.17,0.022667,0.169108,0,0.15,lognormal,low
 CB31,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB44,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB49,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CB52,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.168269,0.033333,0.225862,0,0.1495,lognormal,low
+CB52,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.168269,0.033333,0.225862,0,0.1495,lognormal,low
 CB70,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB74,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB77,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB81,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB97,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB99,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CB101,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.15,0.033333,0.151854,0,0.175,lognormal,low
-CB105,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.00541,0.175,0.016333,0.180065,,,lognormal,low
+CB101,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.15,0.033333,0.151854,0,0.175,lognormal,low
+CB105,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.00541,0.175,0.016333,0.180065,,,lognormal,low
 CB110,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CB118,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.151458,0.03,0.165,0,0.2,lognormal,low
-CB126,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,3.00E-05,0.164144,,,,,lognormal,low
+CB118,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.151458,0.03,0.165,0,0.2,lognormal,low
+CB126,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,3.00E-05,0.164144,,,,,lognormal,low
 CB128,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB132,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB137,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CB138,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.15,0.033333,0.16594,0,0.1875,lognormal,low
+CB138,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.15,0.033333,0.16594,0,0.1875,lognormal,low
 CB138+163,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB149,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CB153,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.139136,0.033333,0.143928,0,0.1875,lognormal,low
-CB156,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003333,0.153069,0.003333,0.174141,,,lognormal,low
+CB153,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.139136,0.033333,0.143928,0,0.1875,lognormal,low
+CB156,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003333,0.153069,0.003333,0.174141,,,lognormal,low
 CB156+172,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB157,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB158,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB167,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CB169,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,1.00E-04,0.14,,,,,lognormal,low
+CB169,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,1.00E-04,0.14,,,,,lognormal,low
 CB170,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CB180,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.15,0.03,0.174141,0,0.2,lognormal,low
+CB180,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.15,0.03,0.174141,0,0.2,lognormal,low
 CB183,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB187,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB189,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CB194,,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-SCB7,Sum of ICES 7 CBs,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.233333,0.128272,,,,,lognormal,low
-SCB6,Sum of ICES 6 CBs,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.2,0.12801,,,,,lognormal,low
+SCB7,Sum of ICES 7 CBs,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.233333,0.128272,,,,,lognormal,low
+SCB6,Sum of ICES 6 CBs,OC-CB,Chlorobiphenyls,Chlorobiphenyls,Chlorobiphenyls,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.2,0.12801,,,,,lognormal,low
 BDE17,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-BDE28,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.002,0.282522,0.006667,0.253731,,,lognormal,low
-BDE47,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003533,0.166667,0.006667,0.15,,,lognormal,low
+BDE28,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.002,0.282522,0.006667,0.253731,,,lognormal,low
+BDE47,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003533,0.166667,0.006667,0.15,,,lognormal,low
 BDE49,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-BDE66,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0015,0.299,0.01,0.197727,,,lognormal,low
+BDE66,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0015,0.299,0.01,0.197727,,,lognormal,low
 BDE71,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 BDE75,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 BDE77,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-BDE85,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.001815,0.217445,0.01,0.192857,,,lognormal,low
-BDE99,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003006,0.230769,0.006667,0.199703,,,lognormal,low
-BD100,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.002679,0.203194,0.008333,0.1954,,,lognormal,low
+BDE85,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.001815,0.217445,0.01,0.192857,,,lognormal,low
+BDE99,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003006,0.230769,0.006667,0.199703,,,lognormal,low
+BD100,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.002679,0.203194,0.008333,0.1954,,,lognormal,low
 BD119,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-BD126,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003006,0.230769,,,,,lognormal,low
+BD126,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003006,0.230769,,,,,lognormal,low
 BD138,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-BD153,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0015,0.25,0.006667,0.224583,,,lognormal,low
-BD154,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.001832,0.267,0.006667,0.222,,,lognormal,low
-BD183,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.002631,0.2655,0.008333,0.3,,,lognormal,low
+BD153,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0015,0.25,0.006667,0.224583,,,lognormal,low
+BD154,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.001832,0.267,0.006667,0.222,,,lognormal,low
+BD183,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.002631,0.2655,0.008333,0.3,,,lognormal,low
 BD190,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-BD209,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.255556,0.27,0.262847,,,lognormal,low
+BD209,,O-BR,PBDEs,PBDEs,PBDEs,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.255556,0.27,0.262847,,,lognormal,low
 PBB153+BD154,,O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-SBDE6,"Sum of BDE 28, 47, 99, 100, 153, 154",O-BR,PBDEs,PBDEs,PBDEs,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.010507,0.1875,,,,,lognormal,low
-HBCD,,O-BR,Organobromines,Organobromines,Organobromines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.016667,0.25,0.07,0.321167,,,lognormal,low
-HBCDA,alpha-HBCD,O-BR,Organobromines,Organobromines,Organobromines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.002238,0.25,0.023333,0.3,,,lognormal,low
-HBCDB,beta-HBCD,O-BR,Organobromines,Organobromines,Organobromines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.043333,0.25,0.023333,0.3,,,lognormal,low
-HBCDG,gamma-HBCD,O-BR,Organobromines,Organobromines,Organobromines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.023333,0.3,0.023333,0.329599,,,lognormal,low
-TBBPA,Tetrabromobiphenol-A,O-BR,Organobromines,Organobromines,Organobromines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.066667,0.25,,,,,lognormal,low
-MPSN+,Monophenyl tin cation,O-MET,Organotins,Organotins,Organotins,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.116667,0.265391,,,lognormal,low
-TPSN+,Triphenyl tin cation,O-MET,Organotins,Organotins,Organotins,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.1,0.24,,,lognormal,low
-DPSN+,Diphenyl tin cation,O-MET,Organotins,Organotins,Organotins,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.116667,0.265426,,,lognormal,low
-TBSN+,Tributyl tin cation,O-MET,Organotins,Organotins,Organotins,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.1,0.24,0.055,0.16,lognormal,low
-MBSN+,Monobutyl tin cation,O-MET,Organotins,Organotins,Organotins,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.116667,0.265391,,,lognormal,low
-DBSN+,Dibutyl tin cation,O-MET,Organotins,Organotins,Organotins,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.116667,0.265426,,,lognormal,low
-ALD,Aldrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.005,0.25,0.006667,0.3,0,0.145625,lognormal,low
+SBDE6,"Sum of BDE 28, 47, 99, 100, 153, 154",O-BR,PBDEs,PBDEs,PBDEs,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.010507,0.1875,,,,,lognormal,low
+HBCD,,O-BR,Organobromines,Organobromines,Organobromines,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.016667,0.25,0.07,0.321167,,,lognormal,low
+HBCDA,alpha-HBCD,O-BR,Organobromines,Organobromines,Organobromines,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.002238,0.25,0.023333,0.3,,,lognormal,low
+HBCDB,beta-HBCD,O-BR,Organobromines,Organobromines,Organobromines,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.043333,0.25,0.023333,0.3,,,lognormal,low
+HBCDG,gamma-HBCD,O-BR,Organobromines,Organobromines,Organobromines,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.023333,0.3,0.023333,0.329599,,,lognormal,low
+TBBPA,Tetrabromobiphenol-A,O-BR,Organobromines,Organobromines,Organobromines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.066667,0.25,,,,,lognormal,low
+MPSN+,Monophenyl tin cation,O-MET,Organotins,Organotins,Organotins,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.116667,0.265391,,,lognormal,low
+TPSN+,Triphenyl tin cation,O-MET,Organotins,Organotins,Organotins,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.1,0.24,,,lognormal,low
+DPSN+,Diphenyl tin cation,O-MET,Organotins,Organotins,Organotins,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.116667,0.265426,,,lognormal,low
+TBSN+,Tributyl tin cation,O-MET,Organotins,Organotins,Organotins,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.1,0.24,0.055,0.16,lognormal,low
+MBSN+,Monobutyl tin cation,O-MET,Organotins,Organotins,Organotins,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.116667,0.265391,,,lognormal,low
+DBSN+,Dibutyl tin cation,O-MET,Organotins,Organotins,Organotins,TRUE,TRUE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.3,0.2,0.116667,0.265426,,,lognormal,low
+ALD,Aldrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.005,0.25,0.006667,0.3,0,0.145625,lognormal,low
 DDEOP,"DDE (o,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-DDEPP,"DDE (p,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.016667,0.180882,0.005,0.26,0,0.146,lognormal,low
-DDTOP,"DDT (o,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.006667,0.2625,0.006667,0.3,0,0.15,lognormal,low
-DDTPP,"DDT (p,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.013333,0.25,0.005,0.26,0,0.077,lognormal,low
-DIELD,Dieldrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003587,0.2,0.012833,0.18828,0,0.15,lognormal,low
-END,Endrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.017167,0.133862,,,0,0.15,lognormal,low
-HCB,Hexachlorobenzene,OC-CL,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0117,0.213483,0.006667,0.376063,0,0.15,lognormal,low
-HCBD,Hexachlorobutadiene,OC-CL,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.022567,0.155608,0.006667,0.376063,0,0.15,lognormal,low
+DDEPP,"DDE (p,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.016667,0.180882,0.005,0.26,0,0.146,lognormal,low
+DDTOP,"DDT (o,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.006667,0.2625,0.006667,0.3,0,0.15,lognormal,low
+DDTPP,"DDT (p,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.013333,0.25,0.005,0.26,0,0.077,lognormal,low
+DIELD,Dieldrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003587,0.2,0.012833,0.18828,0,0.15,lognormal,low
+END,Endrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,TRUE,FALSE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.017167,0.133862,,,0,0.15,lognormal,low
+HCB,Hexachlorobenzene,OC-CL,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0117,0.213483,0.006667,0.376063,0,0.15,lognormal,low
+HCBD,Hexachlorobutadiene,OC-CL,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.022567,0.155608,0.006667,0.376063,0,0.15,lognormal,low
 HCEPC,cis-heptachlorepoxide,OC-CL,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 HCEPT,trans-heptachlorepoxide,OC-CL,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-HCEPX,Heptachlor epoxide,OC-CL,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0139,0.165,0.006667,0.376063,0,0.15,lognormal,low
-HCHA,alpha-HCH,OC-HC,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003483,0.227,0.005167,0.3,0,0.139,lognormal,low
-HCHB,beta-HCH,OC-HC,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.006667,0.231818,0.006667,0.38234,0,0.15,lognormal,low
+HCEPX,Heptachlor epoxide,OC-CL,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0139,0.165,0.006667,0.376063,0,0.15,lognormal,low
+HCHA,alpha-HCH,OC-HC,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.003483,0.227,0.005167,0.3,0,0.139,lognormal,low
+HCHB,beta-HCH,OC-HC,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.006667,0.231818,0.006667,0.38234,0,0.15,lognormal,low
 HCHD,delta-HCH,OC-HC,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-HCHG,gamma-HCH,OC-HC,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0114,0.273053,0.005,0.3,0,0.114,lognormal,low
-HCH,Sum of HCH A B G,OC-HC,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.013333,0.22,,,0,0.1076,lognormal,low
-ISOD,Isodrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.165139,,,0,0.214,lognormal,low
-MCCP,Medium chain chlorinated paraffin,OC-CP,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.333333,0.138965,,,,,lognormal,low
-OCDAN,Oxychlordane,OC-DN,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.001,0.175,,,,,lognormal,low
-SCCP,Short chain chlorinated paraffin,OC-CP,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.333333,0.139728,,,,,lognormal,low
-TDEPP,"TDE (p,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.006667,0.197,0.006667,0.3,0,0.16425,lognormal,low
-CDD1N,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,4.00E-06,0.15,7.30E-05,0.237592,,,lognormal,low
+HCHG,gamma-HCH,OC-HC,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.0114,0.273053,0.005,0.3,0,0.114,lognormal,low
+HCH,Sum of HCH A B G,OC-HC,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.013333,0.22,,,0,0.1076,lognormal,low
+ISOD,Isodrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,TRUE,FALSE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.165139,,,0,0.214,lognormal,low
+MCCP,Medium chain chlorinated paraffin,OC-CP,Organochlorines,Organochlorines,Organochlorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.333333,0.138965,,,,,lognormal,low
+OCDAN,Oxychlordane,OC-DN,Organochlorines,Organochlorines,Organochlorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.001,0.175,,,,,lognormal,low
+SCCP,Short chain chlorinated paraffin,OC-CP,Organochlorines,Organochlorines,Organochlorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.333333,0.139728,,,,,lognormal,low
+TDEPP,"TDE (p,p')",OC-DD,Organochlorines,Organochlorines,Organochlorines,TRUE,TRUE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.006667,0.197,0.006667,0.3,0,0.16425,lognormal,low
+CDD1N,,OC-DX,Dioxins,Dioxins,,TRUE,TRUE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,4.00E-06,0.15,7.30E-05,0.237592,,,lognormal,low
 CDD4X,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CDD6P,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CDD6X,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CDD9X,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CDDO,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-TCDD,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,4.00E-06,0.14,6.00E-05,0.237592,,,lognormal,low
+TCDD,,OC-DX,Dioxins,Dioxins,,TRUE,TRUE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,4.00E-06,0.14,6.00E-05,0.237592,,,lognormal,low
 CDF2N,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-CDF2T,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,8.00E-06,0.149717,6.70E-05,0.237592,,,lognormal,low
+CDF2T,,OC-DX,Dioxins,Dioxins,,TRUE,TRUE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,8.00E-06,0.149717,6.70E-05,0.237592,,,lognormal,low
 CDF4X,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CDF6P,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CDF6X,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
@@ -170,25 +170,25 @@ CDFDN,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYW
 CDFO,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CDFP2,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 CDFX1,,OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,ug/kg,ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-TEQDFP,WHO-TEQ (DFP),OC-DX,Dioxins,Dioxins,,FALSE,FALSE,FALSE,TEQ ug/kg,TEQ ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,1.80E-05,0.1375,3.90E-05,0.237592,,,lognormal,low
-PFOA,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.075,0.178,,,,,lognormal,low
-PFNA,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.05,0.25,,,,,lognormal,low
-PFDA,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.043333,0.249459,,,,,lognormal,low
-PFUNDA,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.04,0.241605,,,,,lognormal,low
-PFDOA,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.046667,0.278512,,,,,lognormal,low
-PFTRDA,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.07,0.26,,,,,lognormal,low
-PFTDA,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.07,0.323489,,,,,lognormal,low
-PFBS,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.34,,,,,lognormal,low
-PFHXS,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.018333,0.129765,,,,,lognormal,low
+TEQDFP,WHO-TEQ (DFP),OC-DX,Dioxins,Dioxins,,TRUE,TRUE,FALSE,TEQ ug/kg,TEQ ug/kg,,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,1.80E-05,0.1375,3.90E-05,0.237592,,,lognormal,low
+PFOA,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.075,0.178,,,,,lognormal,low
+PFNA,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.05,0.25,,,,,lognormal,low
+PFDA,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.043333,0.249459,,,,,lognormal,low
+PFUNDA,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.04,0.241605,,,,,lognormal,low
+PFDOA,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.046667,0.278512,,,,,lognormal,low
+PFTRDA,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.07,0.26,,,,,lognormal,low
+PFTDA,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.07,0.323489,,,,,lognormal,low
+PFBS,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.34,,,,,lognormal,low
+PFHXS,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.018333,0.129765,,,,,lognormal,low
 N-PFHXS,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 BR-PFHXS,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-PFOS,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.066667,0.199772,,,0.003333,0.172725,lognormal,low
+PFOS,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.066667,0.199772,,,0.003333,0.172725,lognormal,low
 N-PFOS,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
 BR-PFOS,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,,,lognormal,low
-PFOSA,,O-FL,Organofluorines,Organofluorines,Organofluorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.171667,0.165,,,,,lognormal,low
-ATRZ,Atrazine,O-TRI,Pesticides,Pesticides,Pesticides,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,0.976667,0.110279,lognormal,low
-GLYPH,Glyphosate,O-HER,Pesticides,Pesticides,Pesticides,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,6.166667,0.202951,lognormal,low
-IMDCP,Imidacloprid,O-INS,Pesticides,Pesticides,Pesticides,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,0.005567,0.15,lognormal,low
+PFOSA,,O-FL,Organofluorines,Organofluorines,Organofluorines,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.171667,0.165,,,,,lognormal,low
+ATRZ,Atrazine,O-TRI,Pesticides,Pesticides,Pesticides,FALSE,FALSE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,0.976667,0.110279,lognormal,low
+GLYPH,Glyphosate,O-HER,Pesticides,Pesticides,Pesticides,FALSE,FALSE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,6.166667,0.202951,lognormal,low
+IMDCP,Imidacloprid,O-INS,Pesticides,Pesticides,Pesticides,FALSE,FALSE,TRUE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,0.005567,0.15,lognormal,low
 CORG,Organic Carbon,O-MAJ,,Auxiliary,,FALSE,FALSE,FALSE,,%,,,AL~CORG~DRYWT%,,,,0.01,0.1,,,,
 LOIGN,Loss on ignition,O-MAJ,,Auxiliary,,FALSE,FALSE,FALSE,,%,,,AL~CORG~DRYWT%,,,,,,,,,
 NORG,Organic Nitrogen,O-MAJ,,Auxiliary,,FALSE,FALSE,FALSE,,%,,,AL~CORG~DRYWT%,,,,,,,,,
@@ -215,25 +215,25 @@ N15,Nitrogen isotope of mass 15,I-RNC,Auxiliary,,,FALSE,FALSE,FALSE,ppt/air,,,,,
 N15D,delta N15 (isotope ratio 15N:14N),I-RNC,Auxiliary,,,FALSE,FALSE,FALSE,ppt,,,,,,,,,,,,,
 MORT%,mortality,B-TOX,,Effects,,FALSE,FALSE,FALSE,,%,,,AL~CORG~DRYWT%,,,,,,,,,
 GOSOI,gonadal somatic index,B-BIO,Effects,,,FALSE,FALSE,FALSE,idx,,,LNMEA~LIPIDWT%~DRYWT%,,,,,,,,,,
-EROD,,B-MBA,Effects,,,FALSE,FALSE,FALSE,pmol/min/mg protein,,,LNMEA~LIPIDWT%~DRYWT%,,,0.5055,0.054412,,,,,lognormal,low
-GST,,B-MBA,Effects,,,FALSE,FALSE,FALSE,nmol/min/mg protein,,,LNMEA~LIPIDWT%~DRYWT%,,,0,0.2,,,,,lognormal,high
-SFG,Scope for growth,B-TOX,Effects,,,FALSE,FALSE,FALSE,j/h/g,,,LNMEA~LIPIDWT%~DRYWT%,,,,,,,,,normal,high
-BAP3OH,3-hydroxy benzo(a)pyrene,B-MBA,Metabolites,,,FALSE,FALSE,FALSE,ng/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.2,,,,,lognormal,low
-NAP2OH,2-hydroxy naphthalene,B-MBA,Metabolites,,,FALSE,FALSE,FALSE,ng/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.175,,,,,lognormal,low
-PA1OH,1-hydroxy phenanthrene,B-MBA,Metabolites,,,FALSE,FALSE,FALSE,ng/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.175,,,,,lognormal,low
+EROD,,B-MBA,Effects,,,TRUE,FALSE,FALSE,pmol/min/mg protein,,,LNMEA~LIPIDWT%~DRYWT%,,,0.5055,0.054412,,,,,lognormal,low
+GST,,B-MBA,Effects,,,TRUE,FALSE,FALSE,nmol/min/mg protein,,,LNMEA~LIPIDWT%~DRYWT%,,,0,0.2,,,,,lognormal,high
+SFG,Scope for growth,B-TOX,Effects,,,TRUE,FALSE,FALSE,j/h/g,,,LNMEA~LIPIDWT%~DRYWT%,,,,,,,,,normal,high
+BAP3OH,3-hydroxy benzo(a)pyrene,B-MBA,Metabolites,,,TRUE,FALSE,FALSE,ng/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.2,,,,,lognormal,low
+NAP2OH,2-hydroxy naphthalene,B-MBA,Metabolites,,,TRUE,FALSE,FALSE,ng/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.175,,,,,lognormal,low
+PA1OH,1-hydroxy phenanthrene,B-MBA,Metabolites,,,TRUE,FALSE,FALSE,ng/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.175,,,,,lognormal,low
 PYR1OH,1-hydroxy pyrene,B-MBA,Metabolites,,,TRUE,FALSE,FALSE,ng/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.15,,,,,lognormal,low
-PYR1OHEQ,1-hydroxy pyrene equivalent,B-MBA,Metabolites,,,FALSE,FALSE,FALSE,ug/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.175,,,,,lognormal,low
-ACHE,,B-MBA,Effects,,,FALSE,FALSE,FALSE,nmol/min/mg protein,,,LNMEA~LIPIDWT%~DRYWT%,,,0,0.4,,,,,lognormal,high
-ALAD,,B-MBA,Effects,,,FALSE,FALSE,FALSE,ng/min/mg protein,,,LNMEA~LIPIDWT%~DRYWT%,,,0,0.2,,,,,lognormal,high
-SURVT,Stress on stress,B-BIO,Effects,,,FALSE,FALSE,FALSE,d,,,LNMEA,,,,,,,,,survival,high
-%DNATAIL,Comet assay,B-MBA,Effects,,,FALSE,FALSE,FALSE,%,,,CMT-QC-NR~LNMEA,,,,,,,,,beta,low
-MNC,Micronucleus assay,B-MBA,Effects,,,FALSE,FALSE,FALSE,nr/1000 cells,,,MNC-QC-NR~LNMEA,,,,,,,,,negativebinomial,low
-NRR,Neutral red retention time,B-MBA,Effects,,,FALSE,FALSE,FALSE,mins,,,LNMEA~LIPIDWT%~DRYWT%,,,,,,,,,survival,high
-LP,Lysosomal labilisation period,B-MBA,Effects,,,FALSE,FALSE,FALSE,mins,,,LNMEA~LIPIDWT%~DRYWT%,,,,,,,,,survival,high
-VDS,Vas Deferens Sequence,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low
+PYR1OHEQ,1-hydroxy pyrene equivalent,B-MBA,Metabolites,,,TRUE,FALSE,FALSE,ug/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.175,,,,,lognormal,low
+ACHE,,B-MBA,Effects,,,TRUE,FALSE,FALSE,nmol/min/mg protein,,,LNMEA~LIPIDWT%~DRYWT%,,,0,0.4,,,,,lognormal,high
+ALAD,,B-MBA,Effects,,,TRUE,FALSE,FALSE,ng/min/mg protein,,,LNMEA~LIPIDWT%~DRYWT%,,,0,0.2,,,,,lognormal,high
+SURVT,Stress on stress,B-BIO,Effects,,,TRUE,FALSE,FALSE,d,,,LNMEA,,,,,,,,,survival,high
+%DNATAIL,Comet assay,B-MBA,Effects,,,TRUE,FALSE,FALSE,%,,,CMT-QC-NR~LNMEA,,,,,,,,,beta,low
+MNC,Micronucleus assay,B-MBA,Effects,,,TRUE,FALSE,FALSE,nr/1000 cells,,,MNC-QC-NR~LNMEA,,,,,,,,,negativebinomial,low
+NRR,Neutral red retention time,B-MBA,Effects,,,TRUE,FALSE,FALSE,mins,,,LNMEA~LIPIDWT%~DRYWT%,,,,,,,,,survival,high
+LP,Lysosomal labilisation period,B-MBA,Effects,,,TRUE,FALSE,FALSE,mins,,,LNMEA~LIPIDWT%~DRYWT%,,,,,,,,,survival,high
+VDS,Vas Deferens Sequence,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low
 VDSI,Vas Deferens Sequence Index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
 IMPS,Imposex stage,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
 PCI,Penis classification index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
-INTS,Intersex stage,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
+INTS,Intersex stage,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
 INTSI,Intersex stage index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
 GSMF63,Grain Size Mass Fraction < 63 micron,P-PHY,,Auxiliary,,FALSE,FALSE,FALSE,,%,,,,,,,,,,,,


### PR DESCRIPTION
Updates OSPAR determinand ref table to say which determinands were assessed in the 2022 assessment (previously, most were set to FALSE).  