### PR TITLE
Issue #265 get_AC bugs

### DIFF
--- a/R/assessment_functions.R
+++ b/R/assessment_functions.R
@@ -46,7 +46,7 @@ run_assessment <- function(
   ctsm_ob$info$AC <- AC
   
   ctsm_ob$info$get_AC_fn <- get_AC_fn
-  if (!is.null(AC) && is.null(ctsm_ob$info$get_AC)) {
+  if (!is.null(AC) && is.null(ctsm_ob$info$get_AC_fn)) {
     ctsm_ob$info$get_AC_fn <- get_AC[[ctsm_ob$info$compartment]]
   }
 


### PR DESCRIPTION
Corrects minor bugs in:
- get_AC; error trapping - error correctly trapped, but error message incorrect
- assessment_engine; didn't correctly pick up user-supplied get_AC function

In addition, made:
- the arguments to the three get_AC functions consistent
- some changes to get_AC$biota to facilitate later user-supplied function for OSPAR assessment
- removed one more ctsm suffix

Tested on HELCOM and OSPAR data sets

This issue is still open. Can now move forward to tailor the OSPAR get_AC function for biota and fully populate reference table