### PR TITLE
Add workflows and pages for external (AMAP) data zips

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -50,6 +50,18 @@ jobs:
           echo "TEMP_DIR=$(mktemp -d)" >> $GITHUB_ENV
           echo "WORK_DIR=$(pwd)" >> $GITHUB_ENV
 
+      - name: Build data and configuration archive for AMAP/external
+        run: |
+          mkdir -p $TEMP_DIR/external
+          cp -R data/example_external_data $TEMP_DIR/external/
+          mv $TEMP_DIR/external/example_external_data $TEMP_DIR/external/data
+          cp -R information/AMAP $TEMP_DIR/external/
+          mv $TEMP_DIR/external/AMAP $TEMP_DIR/external/information
+          cd $TEMP_DIR
+          zip -r $WORK_DIR/docs/external.zip external
+          cd $WORK_DIR
+        continue-on-error: true
+
       - name: Build data and configuration archive for OSPAR 2022
         run: |
           mkdir -p $TEMP_DIR/ospar

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ unzip these anywhere you like on your system.
 
 * <a href="https://osparcomm.github.io/HARSAT/ospar.zip" download>Download the OSPAR archive</a>
 * <a href="https://osparcomm.github.io/HARSAT/helcom.zip" download>Download the HELCOM archive</a>
+* <a href="https://osparcomm.github.io/HARSAT/external.zip" download>Download the external data (AMAP) archive</a>
 
 Let's say you have unzipped these to a file on your system, such as `C:\Users\test\ospar`. So, 
 the data is now in `C:\Users\test\ospar\data`, and the reference files are in `C:\Users\test\ospar\information`,

--- a/index.md
+++ b/index.md
@@ -69,6 +69,7 @@ unzip these anywhere you like on your system.
 
 * <a href="./ospar.zip" download>Download the OSPAR archive</a>
 * <a href="./helcom.zip" download>Download the HELCOM archive</a>
+* <a href="./external.zip" download>Download the external data (AMAP) archive</a>
 
 Let's say you have unzipped these to a file on your system, such as `C:\Users\test\ospar`. So, 
 the data is now in `C:\Users\test\ospar\data`, and the reference files are in `C:\Users\test\ospar\information`,


### PR DESCRIPTION
Resolves #337

## Testing Notes

Only applies when merged to main or run as an action. Logs will need to be checked.

## Technical Notes

1. Adds a new action to build an external zip file from AMAP data
2. Adds links to the new zip file for Github pages