### PR TITLE
Change installation to use remotes::install_local

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ as this ensures that all dependencies are up-to-date, properly downloaded and in
 ### In RStudio
 
 To do this, you will need a downloaded package bundle, typically a file 
-called something like `harsat_0.1.1.tar.gz`.
+called something like `harsat_0.1.2.tar.gz`.
 
 From the `Packages` tab, choose `Install`, make sure you have selected
 to install from a Package Archive File, then press the `Browse...` button
@@ -29,13 +29,15 @@ button.
 ### From the R command line
 
 To do this, you will need a downloaded package bundle, typically a file 
-called something like `harsat_0.1.1.tar.gz`.
+called something like `harsat_0.1.2.tar.gz`.
 
 In the R command line, use a command (passing the filename of wherever 
 you have downloaded the file to):
 
 ```r
-install.packages("~/Downloads/harsat_0.1.1.tar", repos = NULL)
+install.packages(remotes) -- if needed
+library(remotes)
+remotes::install_local("~/Downloads/harsat_0.1.2.tar")
 ```
 ### Directly from Github
 

--- a/index.md
+++ b/index.md
@@ -15,7 +15,7 @@ as this ensures that all dependencies are up-to-date, properly downloaded and in
 ### In RStudio
 
 To do this, you will need a downloaded package bundle, typically a file 
-called something like `harsat_0.1.1.tar.gz`.
+called something like `harsat_0.1.2.tar.gz`.
 
 From the `Packages` tab, choose `Install`, make sure you have selected
 to install from a Package Archive File, then press the `Browse...` button
@@ -25,13 +25,15 @@ button.
 ### From the R command line
 
 To do this, you will need a downloaded package bundle, typically a file 
-called something like `harsat_0.1.1.tar.gz`.
+called something like `harsat_0.1.2.tar.gz`.
 
 In the R command line, use a command (passing the filename of wherever 
 you have downloaded the file to):
 
 ```r
-install.packages("~/Downloads/harsat_0.1.1.tar", repos = NULL)
+install.packages(remotes) -- if needed
+library(remotes)
+remotes::install_local("~/Downloads/harsat_0.1.2.tar")
 ```
 ### Directly from Github
 

--- a/vignettes/harsat.Rmd
+++ b/vignettes/harsat.Rmd
@@ -16,7 +16,7 @@ looks like in a typical analysis.
 ## Installing `harsat` from a bundled package
 
 If you have a downloaded copy of the bundled package, whch will be a file
-named something like `harsat_0.1.1.tar.gz` or `harsat_0.1.1.tar`, you 
+named something like `harsat_0.1.2.tar.gz` or `harsat_0.1.2.tar`, you 
 can install that directly, and R will still take care of making sure 
 you have all the right dependencies.
 
@@ -32,7 +32,7 @@ button.
 Use a command:
 
 ```r
-install.packages("~/Downloads/harsat_0.1.1.tar", repos = NULL)
+install.packages("~/Downloads/harsat_0.1.2.tar", repos = NULL, type="source")
 ```
 
 Use the right file for the downloaded package file, press enter, and

--- a/vignettes/harsat.Rmd.orig
+++ b/vignettes/harsat.Rmd.orig
@@ -22,7 +22,7 @@ looks like in a typical analysis.
 ## Installing `harsat` from a bundled package
 
 If you have a downloaded copy of the bundled package, whch will be a file
-named something like `harsat_0.1.1.tar.gz` or `harsat_0.1.1.tar`, you 
+named something like `harsat_0.1.2.tar.gz` or `harsat_0.1.2.tar`, you 
 can install that directly, and R will still take care of making sure 
 you have all the right dependencies.
 
@@ -38,7 +38,9 @@ button.
 Use a command:
 
 ```r
-install.packages("~/Downloads/harsat_0.1.1.tar", repos = NULL)
+install.packages(remotes) -- if needed
+library(remotes)
+remotes::install_local("~/Downloads/harsat_0.1.2.tar")
 ```
 
 Use the right file for the downloaded package file, press enter, and
@@ -49,6 +51,7 @@ away you go.
 To install the latest development version, use the `remotes` package:
 
 ```r
+# install.packages(remotes) -- if needed
 library(remotes)
 remotes::install_github("osparcomm/harsat", auth_token = 'XXXX') 
 ```


### PR DESCRIPTION
Resolves #343

## Testing Notes

No real testing needed, as this is documentation only. Check that the install process works on a new R deployment, and on an old and dirty and existing one when we can.

## Technical Notes

Background is here: https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/install.packages. But it's not well-described. The issue is the very unusual change in default behaviours for `type` across platforms, and in the absence of meaningful checks for whether it's installing a package file.

However, in the end, a complete different approach is needed. `install.packages()` makes the handling of dependencies much nastier, so we use `remotes::install_local()` instead.