### PR TITLE
Bug 354 determinand always in upper case

### DIFF
--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -737,7 +737,17 @@ read_contaminants <- function(file, data_dir = ".", info) {
     } else {
       data$subseries <- NA_character_
     }
+
     
+    # convert param (determinand) and munit (unit) to upper / lower case
+    
+    data <- dplyr::mutate(
+      data, 
+      param = toupper(.data$param),
+      munit = tolower(.data$munit)
+    )
+    
+        
     return(data)
   }  
   

--- a/R/information_functions.R
+++ b/R/information_functions.R
@@ -505,6 +505,12 @@ ctsm_read_determinand <- function(
   )
   
 
+  
+  # ensure determinand is in upper case 
+  
+  data$determinand <- toupper(data$determinand)
+  
+  
   # fill in common name if missing and create optional variables if missing
   
   data$common_name <- ifelse(


### PR DESCRIPTION
Have ensured that the row names of info$determinand and the determinand values in ICES data extracts are all in upper case.  This was already the case for external data.

Have also ensured that the unit values in ICES data extracts are all in lower case (which makes it the same treatment as for external data).  This needs to be revisited further down the road as TEQ derived variables do currently have upper case units.  But sorting this out is low priority as TEQ variables are not in the data files.