### PR TITLE
Add uncertainty validation for external

### DIFF
--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -836,6 +836,18 @@ read_contaminants <- function(file, data_dir = ".", info) {
       colClasses = var_id[ok]
     )
     
+    # additional validations
+
+    # every valid `uncertainty` must have a valid `unit_uncertainty`
+    uncertainty_present <- which(complete.cases(data$uncertainty))
+    uncertainty_present_valid_units <- 
+      data$unit_uncertainty[uncertainty_present] %in% c("%", "U2", "SD")
+    if (! all(uncertainty_present_valid_units)) {
+      stop(
+        "Missing or invalid uncertainty units for specified uncertainty values. ",
+        "Please check that all uncertainty values have a valid unit: %, U2, or SD"
+      )
+    }
   }
   
 


### PR DESCRIPTION
Resolves #352

## Testing Notes

Should now throw an error when any external file has an `uncertainty` value without a valid, present `unit_uncertainty`

## Technical Notes

Adds uncertainty unit validation and checks