### PR TITLE
Bug 358 sample confusion

### DIFF
--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -1769,20 +1769,26 @@ finalise_data <- function(data, info) {
     method_extraction = "metcx",
     method_pretreatment = "metpt",
     replicate = "tblparamid", 
-    sample = "tblsampleid", 
     upload = "tbluploadid"
   )
 
   
-  # biota specific
+  # compartment specific
   
-  if (info$compartment == "biota") {
+  if (info$compartment %in% c("sediment", "water")) {
+    
+    data <- dplyr::rename(data, sample = "tblsampleid")
+    
+  } else if (info$compartment == "biota") {
+    
     data <- dplyr::rename(
-      data, 
-      sub.sample = "tblbioid", 
+      data,
+      sample_cluster = "tblsampleid", 
+      sample = "tblbioid", 
       sex = "sexco",
       n_individual = "noinp"
     )    
+  
   }
   
   

--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -341,6 +341,15 @@ biota_assessment <- run_assessment(
 
 check_assessment(biota_assessment)
 
+biota_assessment <- update_assessment(
+  biota_assessment, 
+  subset = series == "2299 PYR1OH Limanda limanda BI HPLC-FD",
+  hess.d = 0.0001, hess.r = 8
+)
+
+check_assessment(biota_assessment)
+
+
 
 # And that's it :)
 

--- a/example_OSPAR.r
+++ b/example_OSPAR.r
@@ -243,6 +243,15 @@ biota_assessment <- update_assessment(
 
 check_assessment(biota_assessment)
 
+biota_assessment <- update_assessment(
+  biota_assessment, 
+  subset = series == "5031 BBKF Mytilus edulis SB",
+  hess.d = 0.0001, hess.r = 8
+)
+
+check_assessment(biota_assessment)
+
+
 
 write_summary_table(
   biota_assessment,

--- a/vignettes/example_HELCOM.Rmd.orig
+++ b/vignettes/example_HELCOM.Rmd.orig
@@ -422,7 +422,7 @@ biota_timeseries <- create_timeseries(
 )
 ```
 
-The asssessment took about 3.5 minutes on my laptop
+The asssessment took about 4.3 minutes on my laptop
 
 ```{r helcom-biota-assessment}
 biota_assessment <- run_assessment(
@@ -430,9 +430,27 @@ biota_assessment <- run_assessment(
   AC = c("BAC", "EAC", "EQS", "MPC"),
   parallel = TRUE
 )
+```
+
+One time series has not converged. (The parameter estimates are fine, but the
+standard errors are implausibly tight - if you look at the data, you will see why
+the routines struggle with this time series.) The code below tweaks the 
+arguments of the numerical differencing routine that calculates the standard 
+errors. Dealing with non-converged timeseries is a topic for a future vignette.
+
+
+```{r helcom-biota-check-assessment}
+check_assessment(biota_assessment)
+
+biota_assessment <- update_assessment(
+  biota_assessment, 
+  subset = series == "2299 PYR1OH Limanda limanda BI HPLC-FD",
+  hess.d = 0.0001, hess.r = 8
+)
 
 check_assessment(biota_assessment)
 ```
+
 
 And that's it :)
 

--- a/vignettes/example_OSPAR.Rmd.orig
+++ b/vignettes/example_OSPAR.Rmd.orig
@@ -360,7 +360,22 @@ biota_assessment <- update_assessment(
 )
 ```
 
+One time series has not converged. (The parameter estimates are fine, but the
+standard errors are not available - if you look at the data, you will see why
+the routines struggle with this time series.) The code below tweaks the 
+arguments of the numerical differencing routine that calculates the standard 
+errors. Dealing with non-converged timeseries is a topic for a future vignette.
+
+
 ```{r ospar-biota-check-assessment}
+check_assessment(biota_assessment)
+
+biota_assessment <- update_assessment(
+  biota_assessment, 
+  subset = series == "5031 BBKF Mytilus edulis SB",
+  hess.d = 0.0001, hess.r = 8
+)
+
 check_assessment(biota_assessment)
 ```
 


### PR DESCRIPTION
This resolves bug 358.

For ICES data, sample is now explicity identified in finalise_data, with an additional column sample_cluster available for biota (sample_cluster is essentially a clustering variable to differentiate e.g. fish caught on different trawls).

For external data, there is nothing to change, because users are expected to provide the correct sample variable.

I have tested OSPAR and HELCOM test data sets. For biota, these each provide one timeseries that does not converge, so I have updated the vignettes to deal with that.