### PR TITLE
Issue 353 checking of species and determinand

### DIFF
--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -2121,9 +2121,12 @@ tidy_contaminants <- function(data, info) {
 
   # add required variables 'replicate' and 'pargroup' (not present in external data)
   
+  # have removed 'pargroup' for now as it can result in a lot of unrecognised 
+  # determinands - 'pargroup' is added later in create_timeseries
+  
   if (info$data_format == "external") {
     data$replicate <- seq(from = 1, to = nrow(data), by = 1)
-    data$pargroup <- ctsm_get_info(info$determinand, data$determinand, "pargroup")
+    # data$pargroup <- ctsm_get_info(info$determinand, data$determinand, "pargroup")
   }
   
       
@@ -2227,6 +2230,8 @@ create_timeseries <- function(
   ctsm_check_stations(station_dictionary)
   
   
+  # determinand validation
+  
   # retains determinands of interest, including auxiliary determinands and those
   # required by determinands.control$variables 
   # checks all determinands of interest are recognised by info$determinand
@@ -2297,10 +2302,12 @@ create_timeseries <- function(
   data <- droplevels(data[ok, ])
   
 
+  # species validation
+  
   # drop species that aren't going to be assessed
   # do this after we drop station species combinations because legacy species
   # then don't need to be in the reference tables
-  
+
   if (info$compartment == "biota") {
   
     ok <- ctsm_get_info(info$species, data$species, "assess")
@@ -2339,7 +2346,8 @@ create_timeseries <- function(
 
 
   # add variables that are going to be useful throughout
-  # pargroup in ICES extraction, but can also be got from info$determinand
+  # pargroup is already in an ICES extraction, but might need to supply it
+  # for external data (from info$determinand)
   
   data$group <- ctsm_get_info(
     info$determinand, data$determinand, "group", info$compartment, sep = "_"

--- a/example_external_data.r
+++ b/example_external_data.r
@@ -24,8 +24,8 @@ devtools::load_all()
 biota_data <- read_data(
   compartment = "biota",
   purpose = "AMAP",
-  contaminants = "AMAP_external_data_new_data_only_CAN_MarineMammals.csv",
-  stations = "AMAP_external_new_stations_only.csv",
+  contaminants = "EXTERNAL_FO_PW_DATA.csv",
+  stations = "EXTERNAL_AMAP_STATIONS.csv",
   data_dir = file.path("data", "example_external_data"),
   data_format = "external",
   info_dir = file.path("information", "AMAP"),


### PR DESCRIPTION
For external data, the pargroup variable is now added to the data component of the harsat object in create_timeseries. This greatly simplifies the checking of determinand values:

- `ctsm_check_determinands` identifies all the determinands of interest (those to be assessed, auxiliary determinand, and determinands needed in determinands$control) and checks they are in the reference table
- `ctsm_check_determinands` also deletes all other determinands, so when pargroup is added using `ctsm_get_info`, only recognised deteminands remain

Note that species values are checked after this and after further deletion of all data from station / species combinations with no records in the last X monitoring years (where X is given by `info$recent_years`). This removes the need to worry about legacy species that are no longer of interest and only picks up species that are missing from the reference table and should be assessed.

Tested on OSPAR data (ICES extraction) and external data (which had been updated to read in new external data set)