### PR TITLE
questionable assign call

### DIFF
--- a/R/imposex_functions.R
+++ b/R/imposex_functions.R
@@ -113,9 +113,12 @@ imposex.family <- list(
     devi.calc <- function(i, mu, y) {
       mu <- mu[i]
       y <- y[i]
-      assign("y", y)
-      integrate(function(mu) {(y - mu) / imposex.family$variance(mu)}, lower = mu, upper = y)$value     
-        # double check
+      out <- integrate(
+        function(mu) {(y - mu) / imposex.family$variance(mu)}, 
+        lower = mu, 
+        upper = y
+      )
+      out$value
     }
     devi <- 2 * sapply(1:length(mu), devi.calc, mu = mu, y = y)
     #			sign(y - mu) * sqrt(abs(devi) * w)


### PR DESCRIPTION
Resolves #378 

Removes redundant (legacy) assign call.  I've no idea why this line was present - very old code used to model data that should not be reported (but still are occasionally).

Have tested on made up data and removing the assign call makes no difference to the output.