### PR TITLE
report_assessment fixes bug so works with all info$purpose

### DIFF
--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -918,7 +918,7 @@ report_assessment <- function(
     rmarkdown::render(
       "report_assessment.Rmd", 
       params = list(
-        compartment = info$compartment, 
+        assessment_object = assessment_obj, 
         series = id
       ),
       output_file = output_id, 

--- a/report_assessment.Rmd
+++ b/report_assessment.Rmd
@@ -4,7 +4,7 @@ output:
     css: report_assessment.css
 
 params:
-  compartment: must_supply
+  assessment_object: must_supply
   series: must_supply
 ---
 
@@ -39,7 +39,7 @@ options(width = 110)
 
 #### get key structures ####
 
-assessment_object <- get(paste0(params$compartment, "_assessment"))
+assessment_object <- params$assessment_object
 
 determinands <- ctsm_get_determinands(assessment_object$info)
 
@@ -57,22 +57,22 @@ assessment_object$timeSeries <- dplyr::mutate(
     assessment_object$info$determinand, 
     determinand, 
     "group", 
-    compartment = params$compartment, 
+    compartment = assessment_object$info$compartment, 
     sep = "_"
   )
 )
 
 var_id <- c("station_code", "detGroup")
 
-if (params$compartment == "sediment") {
+if (assessment_object$info$compartment == "sediment") {
   var_id <- c(var_id, "matrix")
 }
 
-if (params$compartment == "water") {
+if (assessment_object$info$compartment == "water") {
   var_id <- c(var_id, "filtration")
 }
 
-if (params$compartment == "biota") {
+if (assessment_object$info$compartment == "biota") {
   var_id <- c(var_id, "species")
   group_id <- assessment_object$timeSeries[params$series, "detGroup"]
   if (!group_id  %in% c("Effects", "Imposex", "Metabolites"))
@@ -194,7 +194,7 @@ if (is.na(info$station_longname)) info$station_longname <- info$station_name
 
 info$matrix <- unique(as.character(data$matrix))
 
-if (params$compartment != "sediment" & length(info$matrix) > 1) 
+if (assessment_object$info$compartment != "sediment" & length(info$matrix) > 1) 
   cat("Error: multiple matrices - need to investigate")
 
 if (length(info$matrix > 1)) {
@@ -223,11 +223,28 @@ if (info$compartment == "biota")
 
 args.list <- list(units = info$unit, basis = info$basis, html = TRUE, compartment = info$compartment)
 
-is_normalised <- info$compartment == "sediment" & !info$ospar_subregion %in% c("Iberian Coast", "Gulf of Cadiz")
-if (is_normalised) {
-  extra.text <- paste("normalised to", switch(info$group, Metals = "5% aluminium", "2.5% organic carbon"))
+is_normalised <- FALSE
+
+if (info$compartment %in% "sediment" && info$purpose %in% "HELCOM") {
+  is_normalised <- TRUE
+  extra.text <- paste(
+    "normalised to", 
+    switch(
+      info$determinand, 
+      CD = "5% aluminium", 
+      PB = "5% aluminium", 
+      "5% organic carbon"
+    ) 
+  )
   args.list <- c(args.list, extra.text)
-}  
+}
+
+if (info$compartment %in% "sediment" && info$purpose %in% "OSPAR" &&
+    !info$ospar_subregion %in% c("Iberian Coast", "Gulf of Cadiz")) {
+  is_normalised <- TRUE
+  extra.text <- paste("normalised to", switch(info$group, Metals = "5% aluminium", "2.5% organic carbon")) 
+  args.list <- c(args.list, extra.text)
+}
 
 info$unit_text <- do.call(label.units, args.list)
 


### PR DESCRIPTION
Issue #377

Fixes two bugs in report_assessment function and markdown:

- ensures code runs whatever info$purpose is set to (previously just worked for OSPAR)
- also realised that the markdown wasn't necessarily picking up the correct assessment_object; this is now rectified.

Note that the fix to get the code running doesn't properly address the question of picking up the correct normalisation parameters.  It is currently correct, but hardwired, for OSPAR and HELCOM sediment assessments.  However, for other assessments, any normalisation that has been done will not be mentioned in the html reports.  (This only affects presentation (not results), but clearly needs to be sorted.  This is something that will follow on naturally from dealing with issue #161 (after first release)  