### PR TITLE
Bug 388 checking uncertainties

### DIFF
--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -910,18 +910,6 @@ read_contaminants <- function(file, data_dir = ".", info) {
       colClasses = var_id[ok]
     )
     
-    # additional validations
-
-    # every valid `uncertainty` must have a valid `unit_uncertainty`
-    uncertainty_present <- which(complete.cases(data$uncertainty))
-    uncertainty_present_valid_units <- 
-      data$unit_uncertainty[uncertainty_present] %in% c("%", "U2", "SD")
-    if (! all(uncertainty_present_valid_units)) {
-      stop(
-        "Missing or invalid uncertainty units for specified uncertainty values. ",
-        "Please check that all uncertainty values have a valid unit: %, U2, or SD"
-      )
-    }
   }
   
 
@@ -969,7 +957,24 @@ read_contaminants <- function(file, data_dir = ".", info) {
   }  
   
 
-
+  
+  # additional validations (for external data)
+  
+  if (info$data_format == "external") { 
+  
+    # every valid `uncertainty` must have a valid `unit_uncertainty`
+    uncertainty_present <- which(complete.cases(data$uncertainty))
+    uncertainty_present_valid_units <- 
+      data$unit_uncertainty[uncertainty_present] %in% c("%", "U2", "SD")
+    if (! all(uncertainty_present_valid_units)) {
+      stop(
+        "Missing or invalid uncertainty units for specified uncertainty values. ",
+        "Please check that all uncertainty values have a valid unit: %, U2, or SD"
+      )
+    }
+  }    
+  
+  
   # check regional identifiers are in the extraction 
 
   # if (info$data_format == "ICES_old") {


### PR DESCRIPTION
Resolves #388

The code to check for valid `unit_uncertainty` values in external data only worked if the columns were present in the data.  The code failed if they were absent (and they are not mandatory).  

I have moved the relevant code to after the point where all the non-optional columns (empty) have been created.

Tested on Swedish external data (not in the repository)
