### PR TITLE
Removed dynamic package usage

### DIFF
--- a/R/graphics_functions.R
+++ b/R/graphics_functions.R
@@ -38,17 +38,6 @@ plot_assessment <- function(
   
   # graphics_functions.R
 
-  if (!"package:lattice" %in% search()) {
-    library("lattice")
-    on.exit(detach("package:lattice"))
-  }
-  
-  if (!"package:grid" %in% search()) {
-    library("grid")
-    on.exit(detach("package:grid"), add = TRUE)
-  }
-
-  
   # check file_type, file_format and output_dir are valid
   
   file_format = match.arg(file_format)

--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -806,17 +806,6 @@ report_assessment <- function(
   
   # reporting_functions.R
   
-  if (!"package:lattice" %in% search()) {
-    library("lattice")
-    on.exit(detach("package:lattice"))
-  }
-  
-  if (!"package:grid" %in% search()) {
-    library("grid")
-    on.exit(detach("package:grid"), add = TRUE)
-  }
-  
-  
   if (!dir.exists(output_dir)) {
     stop(
       "\nThe output directory '", output_dir, "' does not exist.\n", 


### PR DESCRIPTION
## Testing Notes

No changes should show, but the checks should remove warnings for dynamic package usage

## Technical Notes

We have these as dependencies anyway, there is no need to dynamically attach them or detach them.