### PR TITLE
Issue_382 preliminary minor bug fixes

### DIFF
--- a/R/assessment_functions.R
+++ b/R/assessment_functions.R
@@ -287,8 +287,8 @@ assessment_engine <- function(ctsm.ob, series_id, parallel = FALSE, ...) {
 
       thetaID <- switch(
         info$purpose, 
-        CSEMP = stations[station_code, "CMA"],
-        OSPAR = paste(seriesInfo$country, stations[station_code, "OSPAR_subregion"]),
+        # CSEMP = stations[station_code, "CMA"],
+        OSPAR = paste(seriesInfo$country, stations[station_code, "ospar_subregion"]),
         HELCOM = seriesInfo$country
       )
 
@@ -500,13 +500,15 @@ get_index <- function(determinand, data, info) {
       call. = FALSE
     )
   }
-  
+
   
   if (distribution %in% "lognormal") {
     get_index_median(data, log = TRUE)
-  } else if (distribution %in% c("normal", "survival", "multinomial", "quasibinomial")) {
+  } else if (distribution %in% c("normal", "survival")) {
     get_index_median(data, log = FALSE)
-  } else if (distribution %in% c("beta", "negativebinomial")) {
+  } else if (distribution %in% c("multinomial", "quasibinomial")) {
+    get.index.biota.Imposex(data, determinand, info)
+  }else if (distribution %in% c("beta", "negativebinomial")) {
     get_index_weighted_mean(data, determinand) 
   } else {
     stop(

--- a/R/imposex_clm.R
+++ b/R/imposex_clm.R
@@ -155,7 +155,8 @@ imposex.clm.X.change <- function(year, model, model.control = list()) {
   X
 }
 
-  
+
+
 
 imposex.clm.predict <- function(clmFit, theta, data) {
 
@@ -172,7 +173,7 @@ imposex.clm.predict <- function(clmFit, theta, data) {
     Xpred <- do.call(imposex.clm.X.change, args)
   
   clmFit <- within(clmFit, {
-    vcov.unscaled <- 2 * solve(numDeriv::hessian)
+    vcov.unscaled <- 2 * solve(hessian)
     vcov <- vcov.unscaled * disp
     
     summary <- data.frame(est = par, se = sqrt(diag(vcov)))
@@ -198,7 +199,6 @@ imposex.clm.predict <- function(clmFit, theta, data) {
   
   clmFit
 }
-
 
 
 imposex_assess_clm <- function(
@@ -406,7 +406,7 @@ imposex_assess_clm <- function(
   # unidentifiable / undefined) 
   # NB Not sure this is strictly true now that we have banned linear terms before the change point, but 
   # safer to leave it like this for now
-  
+
   hessianInfo <- imposex.clm.fit(within(data, VDS <- VDS2), fit$model, theta, fit$model.control, 
                                  hessian = TRUE)
 

--- a/R/imposex_functions.R
+++ b/R/imposex_functions.R
@@ -242,7 +242,7 @@ assess_imposex <- function(
       VDS[VDS > ntheta] <- ntheta
       VDS <- factor(VDS, levels = 0:ntheta)
     })
-  
+ 
     assessment <- imposex_assess_clm(
       data, theta, annualIndex, species, recent.trend, max.year
     )

--- a/information/AMAP/determinand.csv
+++ b/information/AMAP/determinand.csv
@@ -367,8 +367,8 @@ I131,iodine-131,I-RNC,Radionuclide,,,FALSE,FALSE,FALSE,,,,,,,,,,,,,,,ICES,ICES
 IBPFN,Ibuprofen,OP-GN,Pharmaceuticals,,,FALSE,FALSE,FALSE,,,,,,,,,,,,,,,ICES,ICES
 ICDP,Indeno[123-cd]pyrene,O-PAH,Polycyclic aromatic hydrocarbons,PAH_parent,PAH_parent,TRUE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.063333,0.260325,0.333333,0.114842,0.1,0.15,lognormal,low,OSPAR,ICES
 IMDCP,Imidacloprid,O-INS,Insecticides,Pesticides,Pesticides,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,,,,,0.005567,0.15,lognormal,low,OSPAR,ICES
-IMPS,Imposex stage,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low,OSPAR/HELCOM,ICES
-INTS,Intersex stage,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low,OSPAR/HELCOM,ICES
+IMPS,Imposex stage,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low,OSPAR/HELCOM,ICES
+INTS,Intersex stage,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low,OSPAR/HELCOM,ICES
 INTSI,Intersex stage index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low,OSPAR/HELCOM,ICES
 ISOD,Isodrin,OC-DN,Organochlorines,Organochlorines,Organochlorines,FALSE,FALSE,FALSE,ug/kg,ug/kg,ng/l,LNMEA~LIPIDWT%~DRYWT%,AL~CORG~DRYWT%,,0.033333,0.165139,,,0,0.214,lognormal,low,OSPAR,ICES
 L_PFCAS,L_PFCAS,O-FL,Organofluorines,,,TRUE,FALSE,FALSE,ug/kg,,,,,,,,,,,,lognormal,low,AMAP,

--- a/information/HELCOM_2023/determinand.csv
+++ b/information/HELCOM_2023/determinand.csv
@@ -89,7 +89,7 @@ FATWT%,fat weight,B-BIO,Auxiliary,,,FALSE,FALSE,FALSE,%,,,,,,,,,,,,,
 PYR1OH,1-hydroxy pyrene,B-MBA,Metabolites,,,TRUE,FALSE,FALSE,ng/ml,,,LNMEA~LIPIDWT%~DRYWT%,,,0.123333,0.15,,,,,lognormal,low
 VDS,Vas Deferens Sequence,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low
 VDSI,Vas Deferens Sequence Index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
-IMPS,Imposex stage,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
+IMPS,Imposex stage,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low
 PCI,Penis classification index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
-INTS,Intersex stage,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
+INTS,Intersex stage,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low
 INTSI,Intersex stage index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low

--- a/information/OSPAR_2022/determinand.csv
+++ b/information/OSPAR_2022/determinand.csv
@@ -232,8 +232,8 @@ NRR,Neutral red retention time,B-MBA,Effects,,,TRUE,FALSE,FALSE,mins,,,LNMEA~LIP
 LP,Lysosomal labilisation period,B-MBA,Effects,,,TRUE,FALSE,FALSE,mins,,,LNMEA~LIPIDWT%~DRYWT%,,,,,,,,,survival,high
 VDS,Vas Deferens Sequence,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low
 VDSI,Vas Deferens Sequence Index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
-IMPS,Imposex stage,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
+IMPS,Imposex stage,B-END,Imposex,,,FALSE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low
 PCI,Penis classification index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
-INTS,Intersex stage,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
+INTS,Intersex stage,B-END,Imposex,,,TRUE,FALSE,FALSE,st,,,%FEMALEPOP~LNMEA,,,,,,,,,multinomial,low
 INTSI,Intersex stage index,B-END,Imposex,,,FALSE,FALSE,FALSE,idx,,,%FEMALEPOP~LNMEA,,,,,,,,,quasibinomial,low
 GSMF63,Grain Size Mass Fraction < 63 micron,P-PHY,,Auxiliary,,FALSE,FALSE,FALSE,,%,,,,,,,,,,,,


### PR DESCRIPTION
#382 

When running the OSPAR assessment, I came across some minor errors in the imposex code.  I've fixed some of them here, which clears the way to getting rid of the warnings about biota.VDS.estimates and biota.VDS.cl:

- turn OSPAR to ospar when picking up subregion information (this will be tidied up further with some post-release work on the imposex functions)
- ensure correct annual index is calculated
- remove errant NumDeriv:: which precedes an object, not a function
- update determinand files so that VDS, IMPS and INTS have correct multinomial distribution