### PR TITLE
Improve links between vignettes and reference docs

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -50,6 +50,7 @@ reference:
   - check_assessment
   - write_summary_table
   - plot_assessment
+  - report_assessment
 - title: All functions
 - contents:
   - starts_with("", internal = TRUE)

--- a/vignettes/example_HELCOM.Rmd.orig
+++ b/vignettes/example_HELCOM.Rmd.orig
@@ -61,7 +61,7 @@ cat("```\n")
 
 # Water assessment
 
-First, we use `read_data` to read in the contaminant data, the station
+First, we use `read_data()` to read in the contaminant data, the station
 dictionary, and two important reference tables: the determinand and threshold
 reference tables. There are several things to note about the function call:  
 
@@ -255,14 +255,14 @@ The sediment data are grouped into time series which consist of the
 measurements of single determinand in a single matrix (the fraction the sample
 has been sieved to; e.g. `SED63` or `SEDTOT`) at a single monitoring station.
 
-The `create_timeseries` call for sediment differs from that for water in two
+The `create_timeseries()` call for sediment differs from that for water in two
 ways. First, `determinands.control` identifies two groups of determinands that
 need to be summed. Second, the arguments `normalise` and `normalise.control`
 specify how the normalisation for grain size should be carried out. There are
 default functions for normalisation that will work in many cases. However, the
 process for HELCOM is more complicated (because unlike other metals, copper is
 normalised to organic carbon rather than aluminium) so a customised function
-`normalise_sediment_HELCOM` is provided. The argument `normalise.control`
+`normalise_sediment_HELCOM()` is provided. The argument `normalise.control`
 specifies that metals (apart from copper) will be normalised to 5% aluminium
 and copper and organics will be normalised to 5% organic carbon. The normalise
 functions need a bit of work, so expect them to change.

--- a/vignettes/example_OSPAR.Rmd.orig
+++ b/vignettes/example_OSPAR.Rmd.orig
@@ -56,8 +56,7 @@ cat("```\n")
 
 The OSPAR water assessment is very similar to the HOLAS assessment. The main 
 difference is that more determinands are assessed which means that 
-`determinands.control` needs to do more work in `create_timeseries`. 
-
+`determinands.control` needs to do more work in `create_timeseries()`. 
 
 ```{r ospar-water-data}
 water_data <- read_data(
@@ -137,8 +136,8 @@ knitr::kable(summary.data, format = "html", table.attr = "class=\'datatable\'")
 # Sediment assessment
 
 The main differences in the sediment assessment relate to the normalisation
-procedure in `create_timeseries` and the use of multiple thresholds in 
-`run_assessment`.  
+procedure in `create_timeseries()` and the use of multiple thresholds in 
+`run_assessment()`.  
 
 
 ```{r ospar-sediment-data}
@@ -154,7 +153,7 @@ sediment_data <- read_data(
 sediment_data <- tidy_data(sediment_data)
 ```
 
-A customised function `normalise_sediment_OSPAR` has been written to implement 
+A customised function `normalise_sediment_OSPAR()` has been written to implement 
 the OSPAR normalisation procedure. This is necessary because the pivot values 
 used for normalising metals are region-specific. That aside, the procedure is
 straightforward: all metals are normalised to 5% aluminium and all organics are 
@@ -283,7 +282,7 @@ weight basis, metal concentrations in fish on a wet weight basis, and most
 organic concentrations in fish on either a wet weight or lipid weight basis, 
 depending on the typical lipid content of the fish and tissue. There are also
 rules for birds and mammals. This is dealt with using the customised function
-`get_basis_biota_OSPAR`. 
+`get_basis_biota_OSPAR()`. 
 
 
 ```{r ospar-biota-timeseries}
@@ -325,10 +324,10 @@ biota_timeseries <- create_timeseries(
 ```
 
 Here, we demonstrate how to split up the modelling stage of the assessment into
-several parts. The call to `run_assessment` only assesses the metal time series
-(as specified by the metals in `wk_metals`). The call to `update_assessment` 
+several parts. The call to `run_assessment()` only assesses the metal time series
+(as specified by the metals in `wk_metals`). The call to `update_assessment()` 
 then assesses all the remaining time series. In general, you can subset both
-`run_assessment` and `update_assessment` using any column in the time series
+`run_assessment()` and `update_assessment()` using any column in the time series
 component of `biota_timeseries`; this includes `determinand`, `matrix`, 
 `species` and, as a special case, `series`, if you just want to update
 one or two time series. The latter is particularly useful if a 
@@ -339,7 +338,7 @@ The application of thresholds is also more complicated and can not be handled by
 the standard routines. For example, Background Assessment Concentrations for 
 cadmium and lead in fish are only applied to species / tissue combinations where 
 the lipid content is $>=$ 3%. This is dealt with by using the customised 
-function `get_AC_biota_OSPAR`.
+function `get_AC_biota_OSPAR()`.
 
 
 ```{r ospar-biota-assessment}

--- a/vignettes/harsat.Rmd
+++ b/vignettes/harsat.Rmd
@@ -97,7 +97,7 @@ working.directory <- '/Users/stuart/git/HARSAT'
 
 ## Reading in the data
 
-The first step is to read in the data that we've got.
+The first step is to read in the data that we've got, using `read_data()`.
 We will go through some of these arguments.
 
 
@@ -168,7 +168,7 @@ as is done with the OSPAR estimates.
 
 ## Tidying the data
 
-The next step is to clean the data to prepare for analysis. This step tidies up the 
+The next step is to clean the data to prepare for analysis, using `tidy_data()`. This step tidies up the 
 data structures that we've got there. It does filtering so that we get data in the
  form that we want for say, an OSPAR assessment or a HELCOM assessment.
 It also streamlines some of the data files.
@@ -205,7 +205,7 @@ To this point, we've still not done anything with the datasets.
 
 ## Create a time series
 
-Now we can group the data into time series. This means identifying which data points 
+Now we can group the data into time series, using `create_timeseries()`. This means identifying which data points 
 belong to the same time series, and then set it up as a structure which then allows us 
 to do the assessments.
 

--- a/vignettes/harsat.Rmd.orig
+++ b/vignettes/harsat.Rmd.orig
@@ -106,7 +106,7 @@ cat("```\n")
 
 ## Reading in the data
 
-The first step is to read in the data that we've got.
+The first step is to read in the data that we've got, using `read_data()`.
 We will go through some of these arguments.
 
 ```{r getting-started-read}
@@ -146,7 +146,7 @@ as is done with the OSPAR estimates.
 
 ## Tidying the data
 
-The next step is to clean the data to prepare for analysis. This step tidies up the 
+The next step is to clean the data to prepare for analysis, using `tidy_data()`. This step tidies up the 
 data structures that we've got there. It does filtering so that we get data in the
  form that we want for say, an OSPAR assessment or a HELCOM assessment.
 It also streamlines some of the data files.
@@ -165,7 +165,7 @@ To this point, we've still not done anything with the datasets.
 
 ## Create a time series
 
-Now we can group the data into time series. This means identifying which data points 
+Now we can group the data into time series, using `create_timeseries()`. This means identifying which data points 
 belong to the same time series, and then set it up as a structure which then allows us 
 to do the assessments.
 
@@ -190,7 +190,7 @@ water_timeseries <- create_timeseries(
 
 ## Assessment
 
-The next the next stage is to do the assessment.
+The next the next stage is to do the assessment, using `run_assessment()`.
 
 We've created a time series object, and pass that into this call.
 We have to say which thresholds we're going to use when we do the assessment and there are other options which we can put in here.
@@ -208,7 +208,7 @@ water_assessment <- run_assessment(
 
 There are various little warnings: these ones are nothing to worry about.
 
-We can then check that everything is converged.
+We can then check that everything is converged, using `check_assessment()`.
 
 ```{r getting-started-convergence}
 check_assessment(water_assessment)
@@ -229,7 +229,7 @@ if (!dir.exists(summary.dir)) {
 }
 ```
 
-And then we can generate the summary proper.
+And then we can generate the summary proper, using `write_summary_table()`.
 The summary file which will be very familiar to those who have been involved in the OSPAR and the HELCOM
 assessments. The summary files have information about each time series, 
 what the time series represents (which is the first set of columns), followed


### PR DESCRIPTION
## Testing Notes

Function names referenced in the vignettes should now hyperlink correctly to the reference documentation. Check that with `pkgdown::build_site()`

## Technical Notes

1. Adding parentheses on a function name in R Markdown is needed to make a link.
2. Also, added `report_assessment()` to the "core" functions in the reference pages.