### PR TITLE
Drop the year from the user group contributor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(
     person(given = "OSPAR Commission (OSPAR)", email = "data@ospar.org", role = c("cph", "fnd", "cre", "aut")),
     person(given = "International Council for the Exploration of the Sea (ICES)", email = "info@ices.dk", role = c("cph", "aut")),
     person(given = "AmbieSense Ltd", email = "info@ambiesense.com", role = c("cph", "aut")),
-    person(given = "HARSAT User Group, 2023", email = "harsat@ospar.org", role = c("ctb"))
+    person(given = "HARSAT User Group", email = "harsat@ospar.org", role = c("ctb"))
   )
 Description: Tools for the assessment of data concerning contaminants (hazardous
   substances) and their effects in the marine environment. The code includes


### PR DESCRIPTION
## Testing Notes

N/A

## Technical Notes

The year will only mean we need to change this or add multiples of it at some point. There really doesn't seem to be a need for including the year as part of the group name.