### PR TITLE
extra data required for imposex assessments

### DIFF
--- a/R/imposex_clm.R
+++ b/R/imposex_clm.R
@@ -162,7 +162,7 @@ imposex.clm.X.change <- function(year, model, model.control = list()) {
 imposex.clm.predict <- function(clmFit, theta, data) {
 
   # silence non-standard evaluation warnings
-  est <- se <- disp <- dfResid <- NULL
+  est <- se <- disp <- dfResid <- hessian <- NULL
 
   year <- seq(min(data$year), max(data$year))
   

--- a/man/harsat-package.Rd
+++ b/man/harsat-package.Rd
@@ -28,5 +28,10 @@ Authors:
   \item AmbieSense Ltd \email{info@ambiesense.com} [copyright holder]
 }
 
+Other contributors:
+\itemize{
+  \item HARSAT User Group, 2023 \email{harsat@ospar.org} [contributor]
+}
+
 }
 \keyword{internal}

--- a/man/run_assessment.Rd
+++ b/man/run_assessment.Rd
@@ -11,6 +11,7 @@ run_assessment(
   get_AC_fn = NULL,
   recent_trend = 20L,
   parallel = FALSE,
+  extra_data = NULL,
   ...
 )
 }
@@ -36,6 +37,12 @@ consider trends in the last twenty year.}
 
 \item{parallel}{A logical which determines whether to use parallel
 computation; default = FALSE.}
+
+\item{extra_data}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} A named list used to
+pass additional data to specific assessment routines. At present it is
+only used for imposex assessments, where it passes two data frames called
+\code{VDS_estimates} and \code{VDS_confidence_limits}. Defaults to NULL, This
+argument will be generalised in the near future, so expect it to change.}
 
 \item{...}{Extra arguments which are passed to assessment_engine.  See
 details (which need to be written).}


### PR DESCRIPTION
Resolves #382 (which has already been closed)

The extra information required to run imposex assessments is now passed directly into `run-assessment` using the `extra_data` argument.  The old objects `biota.VDS.est` and 'biota.VDS.cl` are no longer hard-wired into the code, and do not need to be exported when running in parallel.  

The code for using this extra information has been tidied up and some documentation added. 

Tested on the OSPAR 2024 imposex data and produces identical results (when run with parallel = FALSE and TRUE).




