### PR TITLE
Remove remaining refs to Github access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,10 @@ remotes::install_local("~/Downloads/harsat_0.1.2.tar")
 ```
 ### Directly from Github
 
-Alternatively, you can also install `harsat` directly from GitHub. For this to work, at the moment, you will
-need a Github personal access token (the "classic" kind is best), because the repository will be private until
-`harsat` is finally released. As wth bundles, this ensures that all dependencies are up-to-date, properly 
-downloaded and installed.
-
-The short version is as follows:
-
-> The `XXXX` is a Github personal access token. You only need this optional parameter while
-> the `harsat` package is private because it is still under development. 
-> The [Getting Started](https://osparcomm.github.io/HARSAT/articles/harsat.html) guide
-> has more information on how to create a personal access token. 
-
+Alternatively, you can also install `harsat` directly from GitHub. 
 ``` r
 library(remotes)
-remotes::install_github("osparcomm/HARSAT@main", auth_token = 'XXXX')
+remotes::install_github("osparcomm/HARSAT@main")
 ```
 
 The development version is similar, but changes more often, so we only recommend this if you

--- a/index.md
+++ b/index.md
@@ -62,21 +62,11 @@ remotes::install_local("~/Downloads/harsat_0.1.2.tar")
 ```
 ### Directly from Github
 
-Alternatively, you can also install `harsat` directly from GitHub. For this to work, at the moment, you will
-need a Github personal access token (the "classic" kind is best), because the repository will be private until
-`harsat` is finally released. As wth bundles, this ensures that all dependencies are up-to-date, properly 
-downloaded and installed.
-
-The short version is as follows:
-
-> The `XXXX` is a Github personal access token. You only need this optional parameter while
-> the `harsat` package is private because it is still under development. 
-> The [Getting Started](./articles/harsat.html) guide
-> has more information on how to create a personal access token. 
+Alternatively, you can also install `harsat` directly from GitHub. 
 
 ``` r
 library(remotes)
-remotes::install_github("osparcomm/HARSAT@main", auth_token = 'XXXX')
+remotes::install_github("osparcomm/HARSAT@main")
 ```
 
 The development version is similar, but changes more often, so we only recommend this if you
@@ -84,7 +74,7 @@ enjoy a more exciting time for your analysis.
 
 ``` r
 library(remotes)
-remotes::install_github("osparcomm/HARSAT", auth_token = 'XXXX')
+remotes::install_github("osparcomm/HARSAT@develop")
 ```
 
 ## Example usage

--- a/vignettes/harsat.Rmd
+++ b/vignettes/harsat.Rmd
@@ -42,31 +42,20 @@ away you go.
 
 ## Installing `harsat` directly from GitHub
 
-To install the latest development version, use the `remotes` package:
+To install the latest version, use the `remotes` package:
 
 ```r
 # install.packages(remotes) -- if needed
 library(remotes)
-remotes::install_github("osparcomm/harsat", auth_token = 'XXXX') 
+remotes::install_github("osparcomm/harsat@main") 
 ```
 
-The stable version is similar:
+The development version is similar:
 
 ```r
 # install.packages("devtools")
-devtools::install_github("osparcomm/HARSAT@main")
+devtools::install_github("osparcomm/HARSAT@develop")
 ```
-
-> Note: during development the repository is marked as private on GitHub, so you
-> will need a Personal Access Token (or PAT) to access it. Follow
-> [these instructions to create a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
-> It'll be a short string, probably beginning with `ghp_`. Put the whole
-> string into the `auth_token` parameter, and that should install the 
-> `harsat` package directly.
->
-> Please note: we strongly recommend using only "classic" personal access tokens, and avoiding
-> the newer "fine grained" type. When it comes to "scopes" (permissions)
-> you only need to select the `repo` permissions -- no others are needed.
 
 > Note: many of the functions currently have a `cstm` prefix. When the
 > code was originally developed, we thought of it as "contaminant time series modelling", 

--- a/vignettes/harsat.Rmd.orig
+++ b/vignettes/harsat.Rmd.orig
@@ -48,31 +48,20 @@ away you go.
 
 ## Installing `harsat` directly from GitHub
 
-To install the latest development version, use the `remotes` package:
+To install the latest version, use the `remotes` package:
 
 ```r
 # install.packages(remotes) -- if needed
 library(remotes)
-remotes::install_github("osparcomm/harsat", auth_token = 'XXXX') 
+remotes::install_github("osparcomm/harsat@main") 
 ```
 
-The stable version is similar:
+The development version is similar:
 
 ```r
 # install.packages("devtools")
-devtools::install_github("osparcomm/HARSAT@main")
+devtools::install_github("osparcomm/HARSAT@develop")
 ```
-
-> Note: during development the repository is marked as private on GitHub, so you
-> will need a Personal Access Token (or PAT) to access it. Follow
-> [these instructions to create a Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token).
-> It'll be a short string, probably beginning with `ghp_`. Put the whole
-> string into the `auth_token` parameter, and that should install the 
-> `harsat` package directly.
->
-> Please note: we strongly recommend using only "classic" personal access tokens, and avoiding
-> the newer "fine grained" type. When it comes to "scopes" (permissions)
-> you only need to select the `repo` permissions -- no others are needed.
 
 > Note: many of the functions currently have a `cstm` prefix. When the
 > code was originally developed, we thought of it as "contaminant time series modelling", 


### PR DESCRIPTION
See #351

## Testing Notes

N/A -- this only changes documentation

## Technical Notes

This removes final references in the documentation to Github access tokens, which are no longer required now that the repository is public. Only the documentation is affected -- no code changes are included.