### PR TITLE
Allow summaries to be appended

### DIFF
--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -395,13 +395,16 @@ ctsm.web.AC <- function(assessment_ob, classification) {
 #' @param classColour Specifies the colour scheme for the output symbology. 
 #'   Will be changed soon.
 #' @param collapse_AC a names list of valid assessment criteria
+#' @param append Logical. `FALSE` (the default) overwrites any existing summary
+#'   file. `TRUE` appends data to it, creating it if it does not yet exist.
 #'
 #' @returns a summary object, when `export` is `FALSE`
 #'
 #' @export
 write_summary_table <- function(
-  assessment_obj, output_file = NULL, output_dir = ".", export = TRUE, 
-  determinandGroups = NULL, classColour = NULL, collapse_AC = NULL) {
+  assessment_obj, output_file = NULL, output_dir = ".", export = TRUE,
+  determinandGroups = NULL, classColour = NULL, collapse_AC = NULL,
+  append = FALSE) {
 
   # silence non-standard evaluation warnings
   climit_last_year <- NULL
@@ -748,7 +751,7 @@ write_summary_table <- function(
   # write summary to output_file or return summary object
     
   if (export) {
-    readr::write_excel_csv(summary, output_file, na = "")
+    readr::write_excel_csv(summary, output_file, na = "", append = append)
     return(invisible())
   } else {
     return(summary)

--- a/tests/testthat/test-config-plotting.R
+++ b/tests/testthat/test-config-plotting.R
@@ -98,6 +98,25 @@ test_that('plotting works with configurations', {
     data.files <- list.files(My_output_dir, pattern = '\\.csv$')
     expect_equal(data.files, c('GL_RS_SAMBA_NOSUBSERIES.csv'))
 
+    ## Check initial data file size
+    initial.size <- file.size(file.path(My_output_dir, My_output_file))
+    expect_gt(initial.size, 0)
+
+    ## Write the summary again in append mode and check it's now even bigger
+    write_summary_table(
+        biota_assessment,
+        output_file = My_output_file,
+        output_dir = My_output_dir,
+        export = TRUE,
+        determinandGroups = NULL,
+        classColour = NULL,
+        collapse_AC = NULL,
+        append = TRUE
+    )
+
+    final.size <- file.size(file.path(My_output_dir, My_output_file))
+    expect_gt(final.size, initial.size)
+
     ## print("test2")
 
     ## If we pass NULL, all plots should be generated.


### PR DESCRIPTION
Resolves #399

## Testing Notes

With this, passing `append` as `TRUE` to `write_summary_table` should add to any existing summary file, or create it if it does not yet exist. A unit test has been added to work this out.

## Technical Notes

Over and above documentation and unit tests, all this does is add a new `append` parameter `write_summary_table`, and pass the value through to `readr::write_excel_csv`, with some appropriate defaulting.