### PR TITLE
print power metrics

### DIFF
--- a/R/assessment_functions.R
+++ b/R/assessment_functions.R
@@ -1472,11 +1472,12 @@ ctsm_lmm_power <- function(assessment, target_power = 80, target_trend = 10, siz
   # get key data, and return if too few years to compute power
   
   year <- unique(assessment$data$year)
-  n_year <- length(year) 
-  
+
   sd <- assessment$sd_components["sd_index"]
   
-  if (n_year < 3) {
+  method <- assessment$method 
+  
+  if (method == "none") {
     return(out)
   }
   
@@ -1488,7 +1489,7 @@ ctsm_lmm_power <- function(assessment, target_power = 80, target_trend = 10, siz
   
   target_power <- target_power / 100
   
-  if (n_year >= 5) {
+  if (method %in% c("linear", "smooth")) {
     out["dtrend_obs"] <- ctsm_dtrend(year, sd, power = target_power)
     out["dtrend_seq"] <- ctsm_dtrend(min(year):max(year), sd, power = target_power)
   }
@@ -1511,7 +1512,7 @@ ctsm_lmm_power <- function(assessment, target_power = 80, target_trend = 10, siz
   
   # power to detect the specified % change with same options as dtrend
   
-  if (n_year >= 5) {
+  if (method %in% c("linear", "smooth")) {
     out["power_obs"] <- ctsm_dpower(log(1 + target_trend), year, sd)
     out["power_seq"] <- ctsm_dpower(log(1 + target_trend), min(year):max(year), sd)
   }

--- a/man/write_summary_table.Rd
+++ b/man/write_summary_table.Rd
@@ -11,7 +11,9 @@ write_summary_table(
   export = TRUE,
   determinandGroups = NULL,
   classColour = NULL,
-  collapse_AC = NULL
+  collapse_AC = NULL,
+  extra_output = NULL,
+  append = FALSE
 )
 }
 \arguments{
@@ -37,10 +39,18 @@ a csv file).}
 \item{determinandGroups}{optional, a list specifying \code{labels} and \code{levels}
 to label the determinands}
 
-\item{classColour}{Specifies the colour scheme for the output symbology.
-Will be changed soon.}
+\item{classColour}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Specifies the
+colour scheme for the output symbology. Will be changed soon.}
 
 \item{collapse_AC}{a names list of valid assessment criteria}
+
+\item{extra_output}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} A character vector
+specifying extra groups of variables to be included in the output.
+Currently only recognises "power" to give the seven power metrics computed
+for lognormally distributed data. Defaults to \code{NULL}; i.e. no extra output.}
+
+\item{append}{Logical. \code{FALSE} (the default) overwrites any existing summary
+file. \code{TRUE} appends data to it, creating it if it does not yet exist.}
 }
 \value{
 a summary object, when \code{export} is \code{FALSE}

--- a/vignettes/example_external_data.Rmd.orig
+++ b/vignettes/example_external_data.Rmd.orig
@@ -130,7 +130,9 @@ check_assessment(biota_assessment, save_result = FALSE)
 
 # Summary files
 
-This writes the summary data to a file in `output/example_external_data`.
+This writes the summary data to a file in `output/example_external_data`. The 
+argument `extra_output = "power"` ensures that the power metrics for 
+lognormally distributed data will be exported. 
 
 ```{r amap-summary}
 summary.dir <- file.path(working.directory, "output", "example_external_data")
@@ -146,7 +148,8 @@ write_summary_table(
   export = TRUE,
   determinandGroups = NULL,
   classColour = NULL,
-  collapse_AC = NULL
+  collapse_AC = NULL, 
+  extra_output = "power"
 )
 ```
 


### PR DESCRIPTION
Resolves #407

Allows users to print the extra power metrics for lognormally distributed data 
- the extra_output argument can be extended in the future to allow other metrics to be printed
- resolved an inconsistency in the power calculations which I spotted as I went along
- updated external data vignette
- updated documentation
- tested on OSPAR data

The code is not elegant, but does the job, and should suffice until the whole routine is over-hauled.

@morungos If you could review and approve today, then I will continue with the changes to the symbology in the summary table tomorrow.

 
