### PR TITLE
Symbology - allow more flexible choice of thresholds

### DIFF
--- a/example_OSPAR.r
+++ b/example_OSPAR.r
@@ -55,10 +55,12 @@ write_summary_table(
       "Polychlorinated biphenyls", "Organochlorines (other)", "Pesticides"
     )
   ),
-  classColour = list(
-    below = c("EQS" = "green"), 
-    above = c("EQS" = "red"), 
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("EQS" = "green"), 
+      above = c("EQS" = "red"), 
+      none = "black"
+    )
   ),
   collapse_AC = list(EAC = "EQS"),
   output_dir = file.path("output", "example_OSPAR")
@@ -259,56 +261,90 @@ check_assessment(biota_assessment)
 
 
 
+
+
+# environmental summary
+
+wk_groups <- list(
+  levels = c(
+    "Metals", "Organotins", 
+    "PAH_parent", "PAH_alkylated", "Metabolites", 
+    "PBDEs", "Organobromines", 
+    "Organofluorines", 
+    "Chlorobiphenyls", "Dioxins", "Organochlorines",
+    "Effects"
+  ),  
+  labels = c(
+    "Metals", "Organotins", 
+    "PAH parent compounds", "PAH alkylated compounds", "PAH metabolites", 
+    "Polybrominated diphenyl ethers", "Organobromines (other)", 
+    "Organofluorines", 
+    "Polychlorinated biphenyls", "Dioxins", "Organochlorines (other)",
+    "Biological effects (other)"
+  )
+)
+
 write_summary_table(
   biota_assessment,
-  determinandGroups = list(
-    levels = c(
-      "Metals", "Organotins", 
-      "PAH_parent", "PAH_alkylated", "Metabolites", 
-      "PBDEs", "Organobromines", 
-      "Organofluorines", 
-      "Chlorobiphenyls", "Dioxins", "Organochlorines",
-      "Effects"
-    ),  
-    labels = c(
-      "Metals", "Organotins", 
-      "PAH parent compounds", "PAH alkylated compounds", "PAH metabolites", 
-      "Polybrominated diphenyl ethers", "Organobromines (other)", 
-      "Organofluorines", 
-      "Polychlorinated biphenyls", "Dioxins", "Organochlorines (other)",
-      "Biological effects (other)"
+  determinandGroups = wk_groups,
+  symbology = list(
+    colour = list(
+      below = c(
+        "BAC" = "blue",
+        "NRC" = "blue",
+        "EAC" = "green", 
+        "FEQG" = "green",
+        "LRC" = "green", 
+        "QSsp" = "green"
+      ),
+      above = c(
+        "BAC" = "orange", 
+        "NRC" = "orange", 
+        "EAC" = "red", 
+        "FEQG" = "red",
+        "LRC" = "red", 
+        "QSsp" = "red"
+      ),
+      none = "black"
     )
-  ),
-  classColour = list(
-    below = c(
-      "BAC" = "blue",
-      "NRC" = "blue",
-      "EAC" = "green", 
-      "FEQG" = "green",
-      "LRC" = "green", 
-      "QSsp" = "green", 
-      "MPC" = "green",
-      "QShh" = "green"
-    ),
-    above = c(
-      "BAC" = "orange", 
-      "NRC" = "orange", 
-      "EAC" = "red", 
-      "FEQG" = "red",
-      "LRC" = "red", 
-      "QSsp" = "red", 
-      "MPC" = "red",
-      "QShh" = "green"
-    ),
-    none = "black"
   ),
   collapse_AC = list(
     BAC = c("BAC", "NRC"),
     EAC = c("EAC", "FEQG", "LRC", "QSsp"), 
     HQS = c("MPC", "QShh")
   ),
+  output_file = "biota_summary_env.csv",
   output_dir = file.path("output", "example_OSPAR")
 )
+
+
+# health summary
+
+write_summary_table(
+  biota_assessment,
+  determinandGroups = wk_groups,
+  symbology = list(
+    colour = list(
+      below = c(
+        "MPC" = "green", 
+        "QShh" = "green"
+      ),
+      above = c(
+        "MPC" = "red", 
+        "QShh" = "red"
+      ),
+      none = "black"
+    )
+  ),
+  collapse_AC = list(
+    BAC = c("BAC", "NRC"),
+    EAC = c("EAC", "FEQG", "LRC", "QSsp"), 
+    HQS = c("MPC", "QShh")
+  ),
+  output_file = "biota_summary_health.csv",
+  output_dir = file.path("output", "example_OSPAR")
+)
+
 
 
 report_assessment(

--- a/example_external_data.r
+++ b/example_external_data.r
@@ -77,10 +77,12 @@ check_assessment(biota_assessment)
 write_summary_table(
   biota_assessment,
   output_dir = file.path("output", "example_external_data"), 
-  classColour = list(
-    below = c("NRC" = "blue", "LRC" = "green", "MRC" = "orange", "HRC" = "darkorange"),
-    above = c("NRC" = "red", "LRC" = "red", "MRC" = "red", "HRC" = "red"),
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("NRC" = "blue", "LRC" = "green", "MRC" = "orange", "HRC" = "darkorange"),
+      above = c("NRC" = "red", "LRC" = "red", "MRC" = "red", "HRC" = "red"),
+      none = "black"
+    )
   )
 )
 

--- a/man/write_summary_table.Rd
+++ b/man/write_summary_table.Rd
@@ -9,10 +9,10 @@ write_summary_table(
   output_file = NULL,
   output_dir = ".",
   export = TRUE,
-  determinandGroups = NULL,
-  classColour = NULL,
   collapse_AC = NULL,
   extra_output = NULL,
+  symbology = NULL,
+  determinandGroups = NULL,
   append = FALSE
 )
 }
@@ -36,18 +36,21 @@ exist.}
 file. \code{FALSE} returns the summary table as an R object (and does not write to
 a csv file).}
 
+\item{collapse_AC}{A names list of valid assessment criteria that allows
+assessment criteria of the same 'type' to be reported together. See
+details.}
+
+\item{extra_output}{A character vector specifying extra summary metrics
+to be included in the output. Currently only recognises "power" to give the
+seven power metrics computed for lognormally distributed data. Defaults to
+\code{NULL}; i.e. no extra output.}
+
+\item{symbology}{Experimental. Specifies the output symbology. Currently
+assumes the thresholds are presented in increasing magnitude of
+environmental risk.}
+
 \item{determinandGroups}{optional, a list specifying \code{labels} and \code{levels}
 to label the determinands}
-
-\item{classColour}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Specifies the
-colour scheme for the output symbology. Will be changed soon.}
-
-\item{collapse_AC}{a names list of valid assessment criteria}
-
-\item{extra_output}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} A character vector
-specifying extra groups of variables to be included in the output.
-Currently only recognises "power" to give the seven power metrics computed
-for lognormally distributed data. Defaults to \code{NULL}; i.e. no extra output.}
 
 \item{append}{Logical. \code{FALSE} (the default) overwrites any existing summary
 file. \code{TRUE} appends data to it, creating it if it does not yet exist.}
@@ -66,6 +69,6 @@ one-sided 95\% confidence limits
 \item the trend assessments (p-values and trend estimates)
 \item the status assessments (if there any thresholds)
 \item (optionally) a symbology summarising the trend (shape) and status (colour)
-of each time series
+of each time series. This is experimental.
 }
 }

--- a/tests/testthat/test-config-plotting.R
+++ b/tests/testthat/test-config-plotting.R
@@ -90,7 +90,7 @@ test_that('plotting works with configurations', {
         output_dir = My_output_dir,
         export = TRUE,
         determinandGroups = NULL,
-        classColour = NULL,
+        symbology = NULL,
         collapse_AC = NULL
     )
 

--- a/tests/testthat/test-config-plotting.R
+++ b/tests/testthat/test-config-plotting.R
@@ -109,7 +109,7 @@ test_that('plotting works with configurations', {
         output_dir = My_output_dir,
         export = TRUE,
         determinandGroups = NULL,
-        classColour = NULL,
+        symbology = NULL,
         collapse_AC = NULL,
         append = TRUE
     )

--- a/vignettes/example_HELCOM.Rmd.orig
+++ b/vignettes/example_HELCOM.Rmd.orig
@@ -220,10 +220,12 @@ write_summary_table(
     levels = c("Metals", "Organotins", "Organofluorines"), 
     labels = c("Metals", "Organotins", "Organofluorines")
   ),
-  classColour = list(
-    below = c("EQS" = "green"), 
-    above = c("EQS" = "red"), 
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("EQS" = "green"), 
+      above = c("EQS" = "red"), 
+      none = "black"
+    )
   ),
   collapse_AC = list(EAC = "EQS"),
   output_dir = summary.dir
@@ -322,10 +324,12 @@ write_summary_table(
       "Organobromines", "Organobromines" 
     )
   ),
-  classColour = list(
-    below = c("EQS" = "green"), 
-    above = c("EQS" = "red"), 
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("EQS" = "green"), 
+      above = c("EQS" = "red"), 
+      none = "black"
+    )
   ),
   collapse_AC = list(EAC = "EQS"),
   output_dir = summary.dir
@@ -467,10 +471,12 @@ write_summary_table(
       "PCBs and dioxins", "PCBs and dioxins"
     )
   ),
-  classColour = list(
-    below = c("BAC" = "green", "EAC" = "green", "EQS" = "green", "MPC" = "green"),
-    above = c("BAC" = "red", "EAC" = "red", "EQS" = "red", "MPC" = "red"),
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("EQS" = "green"), 
+      above = c("EQS" = "red"), 
+      none = "black"
+    )
   ),
   collapse_AC = list(EAC = c("EAC", "EQS", "MPC")),
   output_dir = summary.dir

--- a/vignettes/example_OSPAR.Rmd.orig
+++ b/vignettes/example_OSPAR.Rmd.orig
@@ -116,10 +116,12 @@ write_summary_table(
       "Polychlorinated biphenyls", "Organochlorines (other)", "Pesticides"
     )
   ),
-  classColour = list(
-    below = c("EQS" = "green"), 
-    above = c("EQS" = "red"), 
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("EQS" = "green"), 
+      above = c("EQS" = "red"), 
+      none = "black"
+    )
   ),
   collapse_AC = list(EAC = "EQS"),
   output_dir = summary.dir
@@ -222,22 +224,24 @@ write_summary_table(
       "Polychlorinated biphenyls", "Dioxins", "Organochlorines (other)"
     )
   ),
-  classColour = list(
-    below = c(
-      "BAC" = "blue", 
-      "ERL" = "green", 
-      "EAC" = "green", 
-      "EQS" = "green", 
-      "FEQG" = "green"
-    ),
-    above = c(
-      "BAC" = "orange", 
-      "ERL" = "red", 
-      "EAC" = "red", 
-      "EQS" = "red", 
-      "FEQG" = "red"
-    ),
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c(
+        "BAC" = "blue", 
+        "ERL" = "green", 
+        "EAC" = "green", 
+        "EQS" = "green", 
+        "FEQG" = "green"
+      ),
+      above = c(
+        "BAC" = "orange", 
+        "ERL" = "red", 
+        "EAC" = "red", 
+        "EQS" = "red", 
+        "FEQG" = "red"
+      ),
+      none = "black"
+    )
   ),
   collapse_AC = list(BAC = "BAC", EAC = c("EAC", "ERL", "EQS", "FEQG")),
   output_dir = summary.dir
@@ -379,6 +383,14 @@ biota_assessment <- update_assessment(
 check_assessment(biota_assessment)
 ```
 
+
+
+We now write the summary table. Here the symbology is based on environmental 
+thresholds. A separate call would be needed to get the symbology based on health 
+thresholds. The symbology functionality is still under development and it is 
+intended to allow both sets of symbologies to be calculated with a single call.
+
+
 ```{r ospar-biota-summary}
 write_summary_table(
   biota_assessment,
@@ -400,28 +412,26 @@ write_summary_table(
       "Biological effects (other)"
     )
   ),
-  classColour = list(
-    below = c(
-      "BAC" = "blue",
-      "NRC" = "blue",
-      "EAC" = "green", 
-      "FEQG" = "green",
-      "LRC" = "green", 
-      "QSsp" = "green", 
-      "MPC" = "green",
-      "QShh" = "green"
-    ),
-    above = c(
-      "BAC" = "orange", 
-      "NRC" = "orange", 
-      "EAC" = "red", 
-      "FEQG" = "red",
-      "LRC" = "red", 
-      "QSsp" = "red", 
-      "MPC" = "red",
-      "QShh" = "red"
-    ),
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c(
+        "BAC" = "blue",
+        "NRC" = "blue",
+        "EAC" = "green", 
+        "FEQG" = "green",
+        "LRC" = "green", 
+        "QSsp" = "green"
+      ),
+      above = c(
+        "BAC" = "orange", 
+        "NRC" = "orange", 
+        "EAC" = "red", 
+        "FEQG" = "red",
+        "LRC" = "red", 
+        "QSsp" = "red"
+      ),
+      none = "black"
+    )
   ),
   collapse_AC = list(
     BAC = c("BAC", "NRC"),
@@ -432,9 +442,7 @@ write_summary_table(
 )
 ```
 
-And finally, let's take a look at the `biota_summary.csv` file. Note that the 
-symbology in the summary table is still under development and currently does
-separate environmental and health tresholds in the status assessment.
+And finally, let's take a look at the `biota_summary.csv` file. 
 
 ```{r ospar-biota-summary-render,echo=FALSE}
 summary.data <- read.csv(file.path(summary.dir, "biota_summary.csv"))

--- a/vignettes/example_external_data.Rmd.orig
+++ b/vignettes/example_external_data.Rmd.orig
@@ -147,7 +147,7 @@ write_summary_table(
   output_dir = summary.dir,
   export = TRUE,
   determinandGroups = NULL,
-  classColour = NULL,
+  symbology = NULL,
   collapse_AC = NULL, 
   extra_output = "power"
 )


### PR DESCRIPTION
Resolves #411

I've fixed the code that was causing me concern. The problem was that the symbology had to be based on all available thresholds, so when there were both environmental and health thresholds, they were combined sometimes leading to silly results.  (There were ad-hoc fixes, but you needed to do some scripting).

Now the user can specify a subset of thresholds to get a symbology for either environmental thresholds or health thresholds.  This should be good enough for first release, although there are further issues that need to be addressed at some point.  I will add these to the issue list.  There is certainly a lot of error checking that needs to be added!

I have updated the vignettes, documentation and tested on both the OSPAR and external data sets.



