### PR TITLE
Update uncertainty processing

### DIFF
--- a/example_HELCOM.r
+++ b/example_HELCOM.r
@@ -154,10 +154,12 @@ write_summary_table(
     levels = c("Metals", "Organotins", "Organofluorines"), 
     labels = c("Metals", "Organotins", "Organofluorines")
   ),
-  classColour = list(
-    below = c("EQS" = "green"), 
-    above = c("EQS" = "red"), 
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("EQS" = "green"), 
+      above = c("EQS" = "red"), 
+      none = "black"
+    )
   ),
   collapse_AC = list(EAC = "EQS"),
   output_dir = file.path("output", "example_HELCOM")
@@ -239,10 +241,12 @@ write_summary_table(
       "Organobromines", "Organobromines" 
     )
   ),
-  classColour = list(
-    below = c("EQS" = "green"), 
-    above = c("EQS" = "red"), 
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("EQS" = "green"), 
+      above = c("EQS" = "red"), 
+      none = "black"
+    )
   ),
   collapse_AC = list(EAC = "EQS"),
   output_dir = file.path("output", "example_HELCOM")
@@ -356,10 +360,12 @@ write_summary_table(
       "PCBs and dioxins", "PCBs and dioxins"
     )
   ),
-  classColour = list(
-    below = c("BAC" = "green", "EAC" = "green", "EQS" = "green", "MPC" = "green"),
-    above = c("BAC" = "red", "EAC" = "red", "EQS" = "red", "MPC" = "red"),
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c("BAC" = "green", "EAC" = "green", "EQS" = "green", "MPC" = "green"),
+      above = c("BAC" = "red", "EAC" = "red", "EQS" = "red", "MPC" = "red"),
+      none = "black"
+    )
   ),
   collapse_AC = list(EAC = c("EAC", "EQS", "MPC")),
   output_dir = file.path("output", "example_HELCOM")

--- a/example_OSPAR.r
+++ b/example_OSPAR.r
@@ -142,22 +142,24 @@ write_summary_table(
       "Polychlorinated biphenyls", "Dioxins", "Organochlorines (other)"
     )
   ),
-  classColour = list(
-    below = c(
-      "BAC" = "blue", 
-      "ERL" = "green", 
-      "EAC" = "green", 
-      "EQS" = "green", 
-      "FEQG" = "green"
-    ),
-    above = c(
-      "BAC" = "orange", 
-      "ERL" = "red", 
-      "EAC" = "red", 
-      "EQS" = "red", 
-      "FEQG" = "red"
-    ),
-    none = "black"
+  symbology = list(
+    colour = list(
+      below = c(
+        "BAC" = "blue", 
+        "ERL" = "green", 
+        "EAC" = "green", 
+        "EQS" = "green", 
+        "FEQG" = "green"
+      ),
+      above = c(
+        "BAC" = "orange", 
+        "ERL" = "red", 
+        "EAC" = "red", 
+        "EQS" = "red", 
+        "FEQG" = "red"
+      ),
+      none = "black"
+    )
   ),
   collapse_AC = list(BAC = "BAC", EAC = c("EAC", "ERL", "EQS", "FEQG")),
   output_dir = file.path("output", "example_OSPAR")
@@ -186,6 +188,12 @@ biota_data <- read_data(
 )  
 
 biota_data <- tidy_data(biota_data)
+
+
+# ad-hoc fix to remove SURVT data for now
+
+biota_data$info$determinand["SURVT", "biota_assess"] <- FALSE
+
 
 biota_timeseries <- create_timeseries(
   biota_data,
@@ -244,7 +252,7 @@ biota_assessment <- run_assessment(
 
 biota_assessment <- update_assessment(
   biota_assessment, 
-  subset = !determinand %in% wk_metals,
+  subset = !determinand %in% wk_metals, 
   parallel = TRUE
 )
 

--- a/example_external_data.r
+++ b/example_external_data.r
@@ -129,3 +129,4 @@ plot_assessment(
   output_dir = file.path("output", "graphics"), 
   file_format = "pdf"
 )
+

--- a/vignettes/example_OSPAR.Rmd.orig
+++ b/vignettes/example_OSPAR.Rmd.orig
@@ -290,6 +290,11 @@ rules for birds and mammals. This is dealt with using the customised function
 
 
 ```{r ospar-biota-timeseries}
+
+# ad-hoc fix to remove SURVT data for now
+
+biota_data$info$determinand["SURVT", "biota_assess"] <- FALSE
+
 biota_timeseries <- create_timeseries(
   biota_data,
   determinands.control = list(


### PR DESCRIPTION
Resolves #420 

Code updated to remove implausibly small uncertainties.  By default relative uncertainties <= 1% or >= 100% are replaced by imputed values.  

The defaults can be changed using `control$relative_uncertainty` in `read_data`.  To replicate the defaults in harsat 1.0.0, set `control$relative_uncertainty = c(0, 100)`.  To keep all uncertainties, regardless of how ridiculous they are, set `control$relative_uncertainty = c(0, Inf)`.

Two minor bugs were identified along the way:

- relative uncertainties were being filtered for all distributional types, but this is only a reliable procedure for determinands with `distribution == "lognormal"`; the checks are now only applied to lognormal data
- some biological effect data with distributions other than normal or lognormal were being incorrectly deleted; this has now been 

The oddity files have been updated to show:

- implausible_uncertainties_reported.csv - all reported uncertainties that are replaced by imputed values
- missing_uncertainties.csv - all uncertainties (normal or lognormal data) that are not reported and can't be imputed
- implausible_uncertaintes_calculated.csv - all uncertainties that are calculated during the data processing (e.g. during normalisation) that are implausible and are set to missing 
 
There is a minor ad-hoc code adjustment in the OSPAR vignette to allow things to run (see #421).  This will be resolved before the next release.