### PR TITLE
ctsm_estimate_uncertainty bug

### DIFF
--- a/R/information_functions.R
+++ b/R/information_functions.R
@@ -2081,6 +2081,10 @@ ctsm_convert_basis <- function(
   
   # set up working data frame
   
+  if (all(exclude)) {
+    return(conc)
+  }
+  
   data <- data.frame(
     conc, from, to, drywt, drywt_censoring, lipidwt, lipidwt_censoring, exclude 
   )


### PR DESCRIPTION
Resolves #443

This is a sensible fix ensuring an early return from `ctsm_convert_basis` if all the data are excluded from the basis conversion.  This is the case when `ctsm_convert_basis` is called from `ctsm_estimate_uncertainty` and all the data are biological effects.  

However there is a bigger issue about the basis conversion in `ctsm_estimate_uncertainty` which is the subject of a future enhancement (#181).   