### PR TITLE
Imposex assessment - ensure reproducibility

### DIFF
--- a/R/proportional_odds_functions.R
+++ b/R/proportional_odds_functions.R
@@ -175,6 +175,8 @@ ctsm.VDS.cl <- function(fit, nsim = 1000) {
   
   indexID <- setdiff(names(fit$par), cutsID)
 
+  set.seed(fit$seed)
+  
   data <- MASS::mvrnorm(nsim, fit$par, fit$vcov)
 
   data.cuts <- data[, cutsID, drop = FALSE]


### PR DESCRIPTION
Resolves #445

Ensures imposex results are fully reproducible by setting an explicit seed for random number generation before constructing confidence limits in `ctsm.VDS.cl`