### PR TITLE
biological effect functionality

### DIFF
--- a/R/information_functions.R
+++ b/R/information_functions.R
@@ -710,6 +710,7 @@ ctsm_get_datatype <- function(determinand, info, abbr = FALSE){
     startsWith(pargroup, "OC-")                ~ "contaminant",
     pargroup %in% c("I-MET", "I-RNC")          ~ "contaminant",
     pargroup %in% c("B-MBA", "B-TOX", "B-END") ~ "effect",
+    determinand %in% "SURVT"                   ~ "effect",
     pargroup %in% c("B-GRS", "B-HST")          ~ "disease",
     TRUE                                       ~ "auxiliary"
   )


### PR DESCRIPTION
See #412

Ensures that SURVT (in pargroup B-BIO) is recognised as an effect in `ctsm_get_datatype`.  (SURVT is the only determinand in this pargroup (so far) that isn't an auxiliary variable.)