### PR TITLE
assess_survival relax constraints on number of years

### DIFF
--- a/R/assessment_functions.R
+++ b/R/assessment_functions.R
@@ -1789,7 +1789,7 @@ assess_survival <- function(
   # have only currently coded for mean and linear - look at ctsm.anyyear.lmm for 
   # extensions to smoothers
 
-  if (determinand %in% c("NRR", "SURVT") & nYear >= 7) {
+  if (determinand %in% c("NRR", "SURVT") & nYear >= 8) {
     stop("time series too long: need to include code for smoothers")
   } 
     


### PR DESCRIPTION
see #412

This is an ad-hoc fix to allow the 2024 CEMP assessment to run for HASEC.  For the first time, we have sufficient SURVT data to fit a smoother, but that needs to be coded in.  For now, just fit a linear trend.  

I will raise an issue to ensure the smoother is coded before the next release.  More generally, it would be advantageous to allow the number of years of data required before a smoother is fitted to be specified by the user.