### PR TITLE
read_data documentation

### DIFF
--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -19,9 +19,8 @@ library(readxl)
 #' @param data_dir The directory where the data files can be found (sometimes
 #'   supplied using 'file.path'). Defaults to "."; i.e. the working directory.
 #' @param data_format A string specifying whether the data were extracted from
-#'   the ICES webservice ("ICES" - the default) or are in the simplified format
-#'   designed for other data sources ("external"). The value "ICES_old" is 
-#'   deprecated.
+#'   the ICES webservice (`"ICES"` - the default) or are in the simplified
+#'   format designed for other data sources (`"external"`).
 #' @param info_files A list of files specifying reference tables which override
 #'   the defaults. See examples.
 #' @param info_dir The directory where the reference tables can be found
@@ -65,13 +64,66 @@ library(readxl)
 #'   `retain == FALSE` are deleted later in `tidy_data`
 #' * `stations`
 #'
-#' ## Control parameters
+#' @details
 #'
-#' Many aspects of the assessment process can be controlled through the
-#' parameters stored in `info$control`. This is a list populated with default
-#' values which can then be overwritten, if required, using the `control`
-#' argument.
+#'   ## Control parameters
 #'
+#'   Many aspects of the assessment process can be controlled through the
+#'   parameters stored in `info$control`. This is a list populated with default
+#'   values which can then be overwritten, if required, using the `control`
+#'   argument.
+#'
+#'   ## External data
+#'
+#'   If `data_format = "external"`, a simplified data and station file can
+#'   be supplied. These should be .csv files, preferably saved with a UTF-8 
+#'   encoding. All missing value should be supplied as empty cells, not as `NA`
+#'   or some other code.    
+#'   
+#'   The data file has one row for each measurement. The mandatory variables 
+#'   are: 
+#'
+#'   * `country`: identifies the source of the data. For international 
+#'   assessments, this is typically the country of origin, but for national 
+#'   assessments it could be a local monitoring authority. It is read in as a 
+#'   character string. 
+#'   * `station_code`: the code of the station where the data were collected. 
+#'   This can be numeric, but is read in as a character string. 
+#'   * `station_name`: the name of the station where the data were collected. 
+#'   This is usually more meaningful to a user than `station_code`. 
+#'   * `year`: an integer giving the monitoring year.
+#'   * `sample`: an identifier that is used to match measurements from the same 
+#'   individual (biota), sediment sample or water sample. This can be numeric, 
+#'   but will be read in as a character string. Take care over this variable as
+#'   if it is incorrectly specified you could lose a lot of data.
+#'   * `determinand`: the code identifying the thing measured. This should 
+#'   match a record in the determinand reference table. 
+#'   * `matrix`: the code identifying the tissue (biota) or size fraction 
+#'   (sediment) of the sample. Use ICES codes at present. For water it should 
+#'   always be set to `"WT"`. 
+#'   * `unit`: the unit of the measurement. Use ICES codes at present.
+#'   * `value`: the numeric value of the measurement. 
+#'    
+#'   The values of `country`, `station_code` and `station_name` (in each row)
+#'   must match an entry in the station file. No missing values are allowed in 
+#'   the mandatory data variables.
+#'  
+#'   The station file has one row for each station. The mandatory variables are: 
+#'   
+#'   * `country`: see data file variables 
+#'   * `station_code`: see data file variables
+#'   * `station_name`: see data file variables
+#'   * `station_latitude`: the nominal latitude of the station (nominal because
+#'   samples are rarely taken at exactly the same location each year). This 
+#'   should be provided as decimal degrees (or a numeric value based on some 
+#'   other projection).
+#'   * `station_longitude`: the nominal longitude of the station. This should 
+#'   be provided as decimal degress (or a numeric value based on some other 
+#'   projection).
+#'
+#'   The optional variables (including the semi-optional regional information)
+#'   will be documented at a later date.
+#'   
 #' @export
 read_data <- function(
   compartment = c("biota", "sediment", "water"), 

--- a/man/read_data.Rd
+++ b/man/read_data.Rd
@@ -33,9 +33,8 @@ read_data(
 supplied using 'file.path'). Defaults to "."; i.e. the working directory.}
 
 \item{data_format}{A string specifying whether the data were extracted from
-the ICES webservice ("ICES" - the default) or are in the simplified format
-designed for other data sources ("external"). The value "ICES_old" is
-deprecated.}
+the ICES webservice (\code{"ICES"} - the default) or are in the simplified
+format designed for other data sources (\code{"external"}).}
 
 \item{info_files}{A list of files specifying reference tables which override
 the defaults. See examples.}
@@ -89,6 +88,14 @@ will be \code{FALSE} if the vflag entry is \code{"S"} or suspect. Records for wh
 }
 \item \code{stations}
 }
+}
+\description{
+Reads in contaminant and effects data, the station dictionary and various
+reference tables. For data from the ICES webservice, it matches data to
+stations in the station dictionary.  It also allows the user to set control
+parameters that dictate the assessment process.
+}
+\details{
 \subsection{Control parameters}{
 
 Many aspects of the assessment process can be controlled through the
@@ -96,10 +103,58 @@ parameters stored in \code{info$control}. This is a list populated with default
 values which can then be overwritten, if required, using the \code{control}
 argument.
 }
+
+\subsection{External data}{
+
+If \code{data_format = "external"}, a simplified data and station file can
+be supplied. These should be .csv files, preferably saved with a UTF-8
+encoding. All missing value should be supplied as empty cells, not as \code{NA}
+or some other code.
+
+The data file has one row for each measurement. The mandatory variables
+are:
+\itemize{
+\item \code{country}: identifies the source of the data. For international
+assessments, this is typically the country of origin, but for national
+assessments it could be a local monitoring authority. It is read in as a
+character string.
+\item \code{station_code}: the code of the station where the data were collected.
+This can be numeric, but is read in as a character string.
+\item \code{station_name}: the name of the station where the data were collected.
+This is usually more meaningful to a user than \code{station_code}.
+\item \code{year}: an integer giving the monitoring year.
+\item \code{sample}: an identifier that is used to match measurements from the same
+individual (biota), sediment sample or water sample. This can be numeric,
+but will be read in as a character string. Take care over this variable as
+if it is incorrectly specified you could lose a lot of data.
+\item \code{determinand}: the code identifying the thing measured. This should
+match a record in the determinand reference table.
+\item \code{matrix}: the code identifying the tissue (biota) or size fraction
+(sediment) of the sample. Use ICES codes at present. For water it should
+always be set to \code{"WT"}.
+\item \code{unit}: the unit of the measurement. Use ICES codes at present.
+\item \code{value}: the numeric value of the measurement.
 }
-\description{
-Reads in contaminant and effects data, the station dictionary and various
-reference tables. For data from the ICES webservice, it matches data to
-stations in the station dictionary.  It also allows the user to set control
-parameters that dictate the assessment process.
+
+The values of \code{country}, \code{station_code} and \code{station_name} (in each row)
+must match an entry in the station file. No missing values are allowed in
+the mandatory data variables.
+
+The station file has one row for each station. The mandatory variables are:
+\itemize{
+\item \code{country}: see data file variables
+\item \code{station_code}: see data file variables
+\item \code{station_name}: see data file variables
+\item \code{station_latitude}: the nominal latitude of the station (nominal because
+samples are rarely taken at exactly the same location each year). This
+should be provided as decimal degrees (or a numeric value based on some
+other projection).
+\item \code{station_longitude}: the nominal longitude of the station. This should
+be provided as decimal degress (or a numeric value based on some other
+projection).
+}
+
+The optional variables (including the semi-optional regional information)
+will be documented at a later date.
+}
 }


### PR DESCRIPTION
Have added in some text on the external data format in the `read_data` documentation.  This was prompted by a question from a user who couldn't read in their external data because they had, quite reasonably, used `NA` for missing values instead of a blank cell.  

The documentation gives a brief overview of the data and station files.  It also describes all the mandatory variables.  The optional variable still need to be documented.

