### PR TITLE
Allow user to specify report file names in report_assessment

### DIFF
--- a/R/import_check_functions.R
+++ b/R/import_check_functions.R
@@ -8,7 +8,6 @@ ctsm_check_variable <- function(data, var_id, info) {
     return(data)
   }
   
-  
   # augment data with four variables: 
   # ok says whether original value is ok and should be retained
   # ok.delete says whether original value is valid but is not to be used in the  
@@ -59,7 +58,7 @@ ctsm_check_variable <- function(data, var_id, info) {
     stop(
       "Not all cases considered when checking '", var_id, "': see '", 
       outfile_name, "'\n", 
-      "You might need to contact the HARSAT development team to fix this.", 
+      "  You might need to contact the HARSAT development team to fix this." 
     )
   }
 

--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -20,7 +20,7 @@ library(readxl)
 #'   supplied using 'file.path'). Defaults to "."; i.e. the working directory.
 #' @param data_format A string specifying whether the data were extracted from
 #'   the ICES webservice (`"ICES"` - the default) or are in the simplified
-#'   format designed for other data sources (`"external"`).
+#'   format designed for other data sources (`"external"`). 
 #' @param info_files A list of files specifying reference tables which override
 #'   the defaults. See examples.
 #' @param info_dir The directory where the reference tables can be found
@@ -76,53 +76,7 @@ library(readxl)
 #'   ## External data
 #'
 #'   If `data_format = "external"`, a simplified data and station file can
-#'   be supplied. These should be .csv files, preferably saved with a UTF-8 
-#'   encoding. All missing value should be supplied as empty cells, not as `NA`
-#'   or some other code.    
-#'   
-#'   The data file has one row for each measurement. The mandatory variables 
-#'   are: 
-#'
-#'   * `country`: identifies the source of the data. For international 
-#'   assessments, this is typically the country of origin, but for national 
-#'   assessments it could be a local monitoring authority. It is read in as a 
-#'   character string. 
-#'   * `station_code`: the code of the station where the data were collected. 
-#'   This can be numeric, but is read in as a character string. 
-#'   * `station_name`: the name of the station where the data were collected. 
-#'   This is usually more meaningful to a user than `station_code`. 
-#'   * `year`: an integer giving the monitoring year.
-#'   * `sample`: an identifier that is used to match measurements from the same 
-#'   individual (biota), sediment sample or water sample. This can be numeric, 
-#'   but will be read in as a character string. Take care over this variable as
-#'   if it is incorrectly specified you could lose a lot of data.
-#'   * `determinand`: the code identifying the thing measured. This should 
-#'   match a record in the determinand reference table. 
-#'   * `matrix`: the code identifying the tissue (biota) or size fraction 
-#'   (sediment) of the sample. Use ICES codes at present. For water it should 
-#'   always be set to `"WT"`. 
-#'   * `unit`: the unit of the measurement. Use ICES codes at present.
-#'   * `value`: the numeric value of the measurement. 
-#'    
-#'   The values of `country`, `station_code` and `station_name` (in each row)
-#'   must match an entry in the station file. No missing values are allowed in 
-#'   the mandatory data variables.
-#'  
-#'   The station file has one row for each station. The mandatory variables are: 
-#'   
-#'   * `country`: see data file variables 
-#'   * `station_code`: see data file variables
-#'   * `station_name`: see data file variables
-#'   * `station_latitude`: the nominal latitude of the station (nominal because
-#'   samples are rarely taken at exactly the same location each year). This 
-#'   should be provided as decimal degrees (or a numeric value based on some 
-#'   other projection).
-#'   * `station_longitude`: the nominal longitude of the station. This should 
-#'   be provided as decimal degress (or a numeric value based on some other 
-#'   projection).
-#'
-#'   The optional variables (including the semi-optional regional information)
-#'   will be documented at a later date.
+#'   be supplied. See `vignette("external-file-format")` for details.
 #'   
 #' @export
 read_data <- function(

--- a/example_OSPAR.r
+++ b/example_OSPAR.r
@@ -75,7 +75,6 @@ report_assessment(
 
 
 
-
 # Sediment ----
 
 sediment_data <- read_data(
@@ -190,11 +189,6 @@ biota_data <- read_data(
 biota_data <- tidy_data(biota_data)
 
 
-# ad-hoc fix to remove SURVT data for now
-
-biota_data$info$determinand["SURVT", "biota_assess"] <- FALSE
-
-
 biota_timeseries <- create_timeseries(
   biota_data,
   determinands.control = list(
@@ -266,9 +260,6 @@ biota_assessment <- update_assessment(
 )
 
 check_assessment(biota_assessment)
-
-
-
 
 
 # environmental summary

--- a/man/read_data.Rd
+++ b/man/read_data.Rd
@@ -107,54 +107,6 @@ argument.
 \subsection{External data}{
 
 If \code{data_format = "external"}, a simplified data and station file can
-be supplied. These should be .csv files, preferably saved with a UTF-8
-encoding. All missing value should be supplied as empty cells, not as \code{NA}
-or some other code.
-
-The data file has one row for each measurement. The mandatory variables
-are:
-\itemize{
-\item \code{country}: identifies the source of the data. For international
-assessments, this is typically the country of origin, but for national
-assessments it could be a local monitoring authority. It is read in as a
-character string.
-\item \code{station_code}: the code of the station where the data were collected.
-This can be numeric, but is read in as a character string.
-\item \code{station_name}: the name of the station where the data were collected.
-This is usually more meaningful to a user than \code{station_code}.
-\item \code{year}: an integer giving the monitoring year.
-\item \code{sample}: an identifier that is used to match measurements from the same
-individual (biota), sediment sample or water sample. This can be numeric,
-but will be read in as a character string. Take care over this variable as
-if it is incorrectly specified you could lose a lot of data.
-\item \code{determinand}: the code identifying the thing measured. This should
-match a record in the determinand reference table.
-\item \code{matrix}: the code identifying the tissue (biota) or size fraction
-(sediment) of the sample. Use ICES codes at present. For water it should
-always be set to \code{"WT"}.
-\item \code{unit}: the unit of the measurement. Use ICES codes at present.
-\item \code{value}: the numeric value of the measurement.
-}
-
-The values of \code{country}, \code{station_code} and \code{station_name} (in each row)
-must match an entry in the station file. No missing values are allowed in
-the mandatory data variables.
-
-The station file has one row for each station. The mandatory variables are:
-\itemize{
-\item \code{country}: see data file variables
-\item \code{station_code}: see data file variables
-\item \code{station_name}: see data file variables
-\item \code{station_latitude}: the nominal latitude of the station (nominal because
-samples are rarely taken at exactly the same location each year). This
-should be provided as decimal degrees (or a numeric value based on some
-other projection).
-\item \code{station_longitude}: the nominal longitude of the station. This should
-be provided as decimal degress (or a numeric value based on some other
-projection).
-}
-
-The optional variables (including the semi-optional regional information)
-will be documented at a later date.
+be supplied. See \code{vignette("external-file-format")} for details.
 }
 }

--- a/man/report_assessment.Rd
+++ b/man/report_assessment.Rd
@@ -8,6 +8,7 @@ report_assessment(
   assessment_obj,
   subset = NULL,
   output_dir = ".",
+  output_file = NULL,
   max_report = 100L
 )
 }
@@ -22,6 +23,10 @@ assessment_obj; use 'series' to identify individual timeseries.}
 \item{output_dir}{The output directory for the assessment plots (possibly
 supplied using 'file.path'). The default is the working directory. The
 output directory must already exist.}
+
+\item{output_file}{An alterntive file name to override the default. This is
+currently only implemented for a single report. If not supplied, the .html
+extension will be added.}
 
 \item{max_report}{The maximum number of reports that will be generated.
 Defaults to 100. Each report is about 1MB in size and takes a few seconds

--- a/vignettes/example_OSPAR.Rmd.orig
+++ b/vignettes/example_OSPAR.Rmd.orig
@@ -291,10 +291,6 @@ rules for birds and mammals. This is dealt with using the customised function
 
 ```{r ospar-biota-timeseries}
 
-# ad-hoc fix to remove SURVT data for now
-
-biota_data$info$determinand["SURVT", "biota_assess"] <- FALSE
-
 biota_timeseries <- create_timeseries(
   biota_data,
   determinands.control = list(

--- a/vignettes/external-file-format.Rmd
+++ b/vignettes/external-file-format.Rmd
@@ -7,22 +7,29 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-These are the column headers for CSV-formatted external data files.
+These are the column headers for CSV-formatted external data files.  The files should be UTF-8 encoded.  
+
+Missing values should be supplied as blank cells, not as `NA` or some other code.
+
+Other columns can also be supplied, but will typically be ignored.
+
 
 ## Contaminant data 
 
+The data file has one row for each measurement.
+
 | column name   | type      | mandatory | comments              |
 | ------------- | --------- | :-------: | --------------------- |
-| `country` | character | yes | must match country in station file<br>no missing values |
-| `station_code` | alphanumeric | yes | must match station_code in station file<br>no missing values |
-| `station_name` | character | yes | must match station_name in station file<br>no missing values |
-| `sample_latitude` | numeric (decimal degrees)  |  | doesn’t need to match station latitude in station file |
-| `sample_longitude` | numeric (decimal degrees)  |  | doesn’t need to match station longitude in station file |
-| `year` | integer | yes | monitoring year<br>doesn’t necessarily match date since a sampling season running from e.g. November 2021 to May 2022 might all be considered the 2022 monitoring year<br>no missing values |
+| `country` | character | yes | identifies the source of the data; for international assessments this is typically the country of origin, but for national assessments it could be a local monitoring authority<br>must match `country` in station file<br>no missing values |
+| `station_code` | alphanumeric | yes | the station (code) where the sample was collected<br>must match `station_code` in station file<br>no missing values |
+| `station_name` | alphanumeric | yes | the station (name) where the sample was collected; this is often more intuitive to a user than `station_code`<br>must match `station_name` in station file<br>no missing values |
+| `sample_latitude` | numeric (decimal degrees)  |  | need not match `station_latitude` in station file |
+| `sample_longitude` | numeric (decimal degrees)  |  | need not match `station_longitude` in station file |
+| `year` | integer | yes | monitoring year<br>doesn’t necessarily match `date` since a sampling season running from e.g. November 2021 to May 2022 might all be considered the 2022 monitoring year<br>no missing values |
 | `date` | date: use ISO 8601 standard e.g. 2023-06-28 |  | sampling date |
-| `depth` | numeric (m) |  | sediment: assumed to be a surface sediment sample with depth being the lower depth of the grab; water: assumed to be a surface water sample with depth being the upper depth of the sample; biota: not used, so can supply whatever is useful (or omit) |
+| `depth` | numeric (m) |  | sediment: assumed to be a surface sediment sample with depth being the lower depth of the grab<br>water: assumed to be a surface water sample with depth being the upper depth of the sample<br>biota: not used, so can supply whatever is useful (or omit) |
 | `species` | character  | yes (biota) | latin name which must match a `submitted_species` in the species reference table | no missing values (biota) |
-| `sex` | character |  | see ICES reference codes for SEXCO<br>required for EROD assessments<br>desirable if sex is used to subdivide timeseries (see subseries) |
+| `sex` | character |  | see ICES reference codes for SEXCO<br>required for EROD assessments<br>desirable if sex is used to subdivide timeseries (see `subseries`) |
 | `n_individual` | integer |  | number of pooled individuals in the sample<br>required for imposex assessments  |
 | `subseries` | character |  | used to split up timeseries by e.g. sex or age<br>for example: `juvenile`, `adult_male`, `adult_female`<br>missing values indicate that all records in a timeseries will be considered together (no subdivision) |
 | `sample` | alphanumeric  | yes | links measurements made on the same individuals (biota), in the same sediment grab or in the same water sample<br>no missing values |
@@ -36,15 +43,17 @@ These are the column headers for CSV-formatted external data files.
 | `limit_quantification` | numeric |  | same unit as value |
 | `uncertainty` | numeric  |  | analytical uncertainty in the measurement<br>same unit as value |
 | `unit_uncertainty` | character |  | `SD`, `U2` or `%`<br>if `uncertainty` is present, `unit_uncertainty` must also be present |
-| `method_pretreatment` | character (ICES metpt list) |  | see ICES reference codes for METPT |
-| `method_analysis` | character (ICES metpt list) |  | see ICES reference codes for METOA<br>required for bile metabolite measurements |
-| `method_extraction` | character (ICES metpt list) |  | see ICES reference codes for METCX<br>required for sediment normalisation (typically for metals) |
+| `method_pretreatment` | character |  | use ICES reference codes for METPT |
+| `method_analysis` | character |  | use ICES reference codes for METOA<br>required for bile metabolite measurements |
+| `method_extraction` | character |  | use ICES reference codes for METCX<br>required for sediment normalisation (typically for metals) |
  
 ## Station data
 
+The station file has one row for each station.
+
 | current_name | Type     | mandatory  | Comments              |
 | ------------ | -------- | :--------: | --------------------- |
-| `OSPAR_region` | character |  | the regional columns can be called anything (and are optional)<br>OSPAR: use `OSPAR_region` and `OSPAR_subregion`<br>HELCOM: use `HELCOM_subbasin`, `HELCOM_L3` and `HELCOM_L4` |
+| `OSPAR_region` | character |  | the regional columns can be called anything (and are optional)<br>for OSPAR assessments, use `OSPAR_region` and `OSPAR_subregion`<br>for HELCOM assessments use `HELCOM_subbasin`, `HELCOM_L3` and `HELCOM_L4`<br>for other assessments any regional columns must be explicitly identified when calling `read_data` using the `control` argument |
 | `OSPAR_subregion` | character |  | see above |
 | `country` | character | yes | no missing values |
 | `station_code` | alphanumeric | yes | no missing values |

--- a/vignettes/reference-file-formats.Rmd
+++ b/vignettes/reference-file-formats.Rmd
@@ -7,7 +7,8 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-These are the column headers for CSV-formatted reference table files.
+These are the column headers for CSV-formatted reference table files. Ideally, the files should be UTF-8 encoded.
+
 `harsat` uses three different reference tables: 
 
 1. A species file
@@ -17,6 +18,8 @@ These are the column headers for CSV-formatted reference table files.
 All these files should be in your information files directory.  
 
 Do not use any forward or backward slashes in the reference files.
+
+Missing values should be supplied as blank cells, not as `NA`.
 
 The order of the columns does not matter, as long as they are named consistently with the specification below.
 
@@ -67,7 +70,7 @@ The determinand file will be `determinand.csv` in your information files directo
 | `sediment_auxiliary` | character | yes* | yes | Identifies all the auxiliary measurements that should be associated with the determinand. These should be separated by a `~`. For example, for metal contaminants, this might be 'AL~LI~CORG' |
 | `water_auxiliary` | character | yes" | yes | Identifies all the auxiliary measurements that should be associated with the determinand. These should be separated by a `~`. Not currently used much for water assessments |
 | `biota_sd_constant` | character | no | yes | If supplied, this allows the imputation of measurement uncertainty for determinands in a biota assessment when they are missing from the data file. `sd_constant` is the constant error with units given by `biota_unit` |
-| `biota_sd_variable` | character | no | yes | If supplied, this allows the imputation of measurement uncertainty for determinands in a biota assessment when they are missing from the data file. `sd_constant` is the proportional error expressed as a percentage (%) |
+| `biota_sd_variable` | character | no | yes | If supplied, this allows the imputation of measurement uncertainty for determinands in a biota assessment when they are missing from the data file. `sd_variable` is the proportional error expressed as a percentage (%) |
 | `sediment_sd_constant` | character | no | yes | See `biota_sd_constant` |
 | `sediment_sd_variable` | character | no | yes | See `biota_sd_variable` |
 | `water_sd_constant` | character | no | yes | See `biota_sd_constant` |


### PR DESCRIPTION
Resolves #455 
Resolves #421 

User can now specify report file names in `report_assessment`.  Can only specify a single file name for a single report.  Otherwise will fail with suitable error message.

Various other minor fixes:

- remove add hoc fix in OSPAR example related to SURVT
- fix minor bug in error message in import check functions
- tidy up some documentation

Checked on OSPAR example