### PR TITLE
auxiliary variables plot

### DIFF
--- a/R/graphics_functions.R
+++ b/R/graphics_functions.R
@@ -38,23 +38,36 @@
 #'   
 #'   ## Auxiliary variables
 #' 
-#'   The default (`auxiliary = "default`) is to plot the following variables:  
+#'   The default (`auxiliary = "default"`) is to plot the following variables:  
 #'   
-#'   * biota: concentration, LNMEA (mean length), DRYWT% (dry weight content), 
-#'   LIPIDWT% (lipi weight content)
-#'   * sediment: non-normalised concentration, normalised concentration, AL 
-#'   (aluminiun concentration), CORG (organic carbon content)
+#'   * biota: determinand concentration, LNMEA (mean length), DRYWT% (dry weight 
+#'   content), LIPIDWT% (lipi weight content)
+#'   * sediment: non-normalised determinand concentration, normalised 
+#'   determinand concentration, AL (aluminium concentration), CORG (organic 
+#'   carbon content)
 #'   * water: no plots are generated at present
 #'   
-#'   At present, it is only possible to change the last three variable for biota 
-#'   and the last two variables for sediment. For example, for metals in 
-#'   sediment, you might specify `auxiliary = c("AL", "LI")` to plot aluminium
-#'   and lithium concentrations instead of aluminium and organic carbon.
+#'   For biota, the determinand concentration will always be plotted, but it is 
+#'   possible to change the three auxiliary variables. For example, to plot 
+#'   WTMEA (mean weight) instead of LIPIDWT% you would set `auxiliary = 
+#'   c("LNMEA", "WTMEA", "DRYWT%)`. For this to work, WTMEA must previously have
+#'   been specified as an auxiliary variable for the determinand in question 
+#'   using the `biota_auxliary` column in the determinand reference table. At 
+#'   present, there must always be three auxiliary variables for biota.
 #'   
-#'   The auxiliary variables must be specified as such in the determinand 
-#'   reference table in e.g. the `biota_auxiliary` or `sediment_auxiliary` 
-#'   column. At present, plots for only a limited range of auxiliary variables 
-#'   are supported. 
+#'   For sediment, the non-normalised determinand concentration and the 
+#'   normalised determinand concentration will always be plotted, but it is 
+#'   possible to change the two auxiliary variables. For example, for metals in 
+#'   sediment, you might set `auxiliary = c("AL", "LI")` to plot aluminium
+#'   and lithium concentrations instead of aluminium and organic carbon 
+#'   concentrations. Again, for this to work, LI must previously have been 
+#'   specified as an auxiliary variable for the determinand in question using 
+#'   the `sediment_auxliary` column in the determinand reference table. 
+#'   At present, there must always be two auxiliary variables for sediment.
+#'   
+#'   At present, plots for only a limited range of auxiliary variables are 
+#'   supported. More flexibility in these plots, such as changing the number of 
+#'   auxiliary variables, is desirable and will emerge in due course.
 #'
 #' @export
 plot_assessment <- function(

--- a/inst/markdown/report_assessment.Rmd
+++ b/inst/markdown/report_assessment.Rmd
@@ -627,14 +627,14 @@ txt <- if (anova_ok) "Finally, the tab" else "The tab also"
 #### Assessment plot
 
 ```{r assessment_plot, echo = FALSE, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 7}
-plot.data(data, assessment, info, assessment_object$info, type = "assessment", xykey.cex = 1.4)
+plot_data(data, assessment, info, assessment_object$info, type = "assessment", xykey.cex = 1.4)
 ```
 
 
 #### Trend with data
 
 ```{r data_plot, echo = FALSE, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 7}
-plot.data(data, assessment, info, assessment_object$info, type = "data", xykey.cex = 1.4)
+plot_data(data, assessment, info, assessment_object$info, type = "data", xykey.cex = 1.4)
 ```
 
 

--- a/man/plot_assessment.Rd
+++ b/man/plot_assessment.Rd
@@ -8,8 +8,9 @@ plot_assessment(
   assessment_obj,
   subset = NULL,
   output_dir = ".",
-  file_type = c("data", "index"),
-  file_format = c("png", "pdf")
+  file_type = c("data", "index", "auxiliary"),
+  file_format = c("png", "pdf"),
+  auxiliary = "default"
 )
 }
 \arguments{
@@ -18,26 +19,62 @@ run_assessment}
 
 \item{subset}{An optional vector specifying which timeseries are to be
 plotted. An expression will be evaluated in the timeSeries component of
-assessment_obj; use 'series' to identify individual timeseries.}
+assessment_obj; use \code{series} to identify individual timeseries.}
 
 \item{output_dir}{The output directory for the assessment plots (possibly
-supplied using 'file.path'). The default is the working directory. The
+supplied using \code{file.path}). The default is the working directory. The
 output directory must already exist.}
 
-\item{file_type}{Specifies whether the plots show the raw data ('file_type =
-"data"'), annual indices summarising the data for each year ('file_type =
-"index"'), or (the default) whether two files should be produced for each
-time series, one with the raw data and one with the annual indices.}
+\item{file_type}{A character vector specifying the types of assessment plot.
+The default \code{c("data", "index", "auxiliary")} produces three plots for
+each time series. See details}
 
-\item{file_format}{Whether the files should be png (the default) or pdf.}
+\item{file_format}{A character string specifying Whether the files should be
+png (the default) or pdf.}
+
+\item{auxiliary}{A character string specifying the auxiliary variables
+plotted if \code{file_type = "auxiliary"}. See details}
 }
 \value{
 A series of png or pdf files with graphical summaries of an
-assessment. The plots show the fitted trends with pointwise two-sided 90\%
-confidence limits and either the raw data, or indices summarising the data
-for each year.
+assessment.
 }
 \description{
-Generates a series of assessment plots with the raw data, or the annual
-indices, or both. The plots are exported as either png or pdf files.
+Generates a series of assessment plots for each time series. The plots are
+exported as either png or pdf files.
+}
+\details{
+\subsection{Types of assessment plots}{
+\itemize{
+\item \code{file_type = "data"} shows the raw data with the fitted trend and
+pointwise two-sided 90\% confidence bands
+\item \code{file_type = "index"} shows annual indices that summarise the data for
+each year with the fitted trend and pointwise two-sided 90\% confidence
+bands
+\item \code{file_type = "auxiliary"} shows the raw data and key auxiliary variables
+see below)
+}
+}
+
+\subsection{Auxiliary variables}{
+
+The default (\verb{auxiliary = "default}) is to plot the following variables:
+\itemize{
+\item biota: concentration, LNMEA (mean length), DRYWT\% (dry weight content),
+LIPIDWT\% (lipi weight content)
+\item sediment: non-normalised concentration, normalised concentration, AL
+(aluminiun concentration), CORG (organic carbon content)
+\item water: no plots are generated at present
+}
+
+At present, it is only possible to change the last three variable for biota
+and the last two variables for sediment. For example, for metals in
+sediment, you might specify \code{auxiliary = c("AL", "LI")} to plot aluminium
+and lithium concentrations instead of aluminium and organic carbon.
+
+The auxiliary variables must be specified as such in the determinand
+reference table in e.g. the \code{biota_auxiliary} or \code{sediment_auxiliary}
+column. At present, plots for only a limited range of auxiliary variables
+are supported.
+}
 }

--- a/man/plot_assessment.Rd
+++ b/man/plot_assessment.Rd
@@ -58,23 +58,35 @@ see below)
 
 \subsection{Auxiliary variables}{
 
-The default (\verb{auxiliary = "default}) is to plot the following variables:
+The default (\code{auxiliary = "default"}) is to plot the following variables:
 \itemize{
-\item biota: concentration, LNMEA (mean length), DRYWT\% (dry weight content),
-LIPIDWT\% (lipi weight content)
-\item sediment: non-normalised concentration, normalised concentration, AL
-(aluminiun concentration), CORG (organic carbon content)
+\item biota: determinand concentration, LNMEA (mean length), DRYWT\% (dry weight
+content), LIPIDWT\% (lipi weight content)
+\item sediment: non-normalised determinand concentration, normalised
+determinand concentration, AL (aluminium concentration), CORG (organic
+carbon content)
 \item water: no plots are generated at present
 }
 
-At present, it is only possible to change the last three variable for biota
-and the last two variables for sediment. For example, for metals in
-sediment, you might specify \code{auxiliary = c("AL", "LI")} to plot aluminium
-and lithium concentrations instead of aluminium and organic carbon.
+For biota, the determinand concentration will always be plotted, but it is
+possible to change the three auxiliary variables. For example, to plot
+WTMEA (mean weight) instead of LIPIDWT\% you would set \verb{auxiliary =  c("LNMEA", "WTMEA", "DRYWT\%)}. For this to work, WTMEA must previously have
+been specified as an auxiliary variable for the determinand in question
+using the \code{biota_auxliary} column in the determinand reference table. At
+present, there must always be three auxiliary variables for biota.
 
-The auxiliary variables must be specified as such in the determinand
-reference table in e.g. the \code{biota_auxiliary} or \code{sediment_auxiliary}
-column. At present, plots for only a limited range of auxiliary variables
-are supported.
+For sediment, the non-normalised determinand concentration and the
+normalised determinand concentration will always be plotted, but it is
+possible to change the two auxiliary variables. For example, for metals in
+sediment, you might set \code{auxiliary = c("AL", "LI")} to plot aluminium
+and lithium concentrations instead of aluminium and organic carbon
+concentrations. Again, for this to work, LI must previously have been
+specified as an auxiliary variable for the determinand in question using
+the \code{sediment_auxliary} column in the determinand reference table.
+At present, there must always be two auxiliary variables for sediment.
+
+At present, plots for only a limited range of auxiliary variables are
+supported. More flexibility in these plots, such as changing the number of
+auxiliary variables, is desirable and will emerge in due course.
 }
 }

--- a/vignettes/example_external_data.Rmd.orig
+++ b/vignettes/example_external_data.Rmd.orig
@@ -40,7 +40,7 @@ cat("```\n")
 
 # Read data
 
-Mercury data with supporting variables and station dictionary
+Contaminant data with supporting variables and station dictionary
 
 ```{r amap-biota}
 biota_data <- read_data(
@@ -155,8 +155,10 @@ write_summary_table(
 
 # Graphics output
 
-Plots assessment with either data (file_type = "data") or annual index 
-(file_type = "index") or both (default)
+Plots the fitted trend with pointwise 90% confidence bands and either the data 
+(`file_type = "data"`) or the annual index (`file_type = "index"`) or plots the 
+raw data with key auxiliary variables (`file_type = "auxiliary"`). The default 
+is to plot all three.
 
 The plot function writes output to `output_dir` directory (must exist); with these
 settings all plots are output as .png formatted graphics; function can be omitted to 
@@ -180,9 +182,10 @@ if (!dir.exists(graphics.dir)) {
 plot_assessment(
   biota_assessment,
   subset = NULL ,
-  output_dir = summary.dir,
-  file_type = c("data", "index"),
-  file_format = c("png" )
+  output_dir = graphics.dir,
+  file_type = c("data", "index", "auxiliary"),
+  file_format = "png",
+  auxiliary = "default"
 )
 ```
 


### PR DESCRIPTION
Issue #409
`plot_assessment` now also plots the raw data with key auxiliary variables. This is achieved by '`file_type = "auxiliary"`. The default variables are:

- biota: concentration, LNMEA, DRYWT%, LIPIDWT%
- sediment: non-normalised concentration, normalised concentration, AL, CORG
- water: no plots are currently produced

The choice of auxiliary variables can be altered using the `auxiliary` argument, although the options here are still limited.

Tested with the HELCOM and AMAP data.
Documentation updated.
AMAP vignette (which demonstrates `plot_assessment`) updated.

To close off this issue, still need to:

- update multi-series plots
- update ratio plots
- reintroduce these plots into the html reports for each time series
- remove warning about the distribution of MNC data
