### PR TITLE
update treatment of auxiliary variables

### DIFF
--- a/R/import_check_functions.R
+++ b/R/import_check_functions.R
@@ -155,7 +155,7 @@ ctsm.check.basis.biota <- function(data, info) {
       new[!ok] <- "W"
     })
 
-  id <- data$determinand %in% c("EXLIP%", "FATWT%", "LIPIDWT%")
+  id <- data$determinand %in% c("EXLIP%", "FATWT%", "LIPIDWT%", "WTMEA")
   if (any(id))
     data[id,] <- within(data[id,], {    
       ok <- basis %in% c("W", "D")
@@ -164,8 +164,8 @@ ctsm.check.basis.biota <- function(data, info) {
     })
 
   id <- data$determinand %in% c(
-    "VDS", "IMPS", "INTS", "VDSI", "PCI", "INTSI", "%FEMALEPOP", "SURVT", "NRR", "LP", "%DNATAIL", 
-    "MNC", "CMT-QC-NR", "MNC-QC-NR")
+    "VDS", "IMPS", "INTS", "VDSI", "PCI", "INTSI", "%FEMALEPOP", "SURVT", "NRR", 
+    "LP", "%DNATAIL", "MNC", "CMT-QC-NR", "MNC-QC-NR")
   if (any(id))
     data[id,] <- within(data[id,], {    
       ok <- is.na(basis)
@@ -250,7 +250,7 @@ ctsm.check.matrix.biota <- function(data, info) {
   # actually LNMEA could be feather length (but have not allowed for this at present)
   # NB procedures for merging with LNMEA are similary complicated for birds
 
-  id <- data$determinand %in% "LNMEA"
+  id <- data$determinand %in% c("LNMEA", "WTMEA")
   if (any(id))
     data[id,] <- within(data[id,], {
       ok <- (species_group %in% c("Fish", "Mammal") & matrix %in% "WO") |
@@ -513,8 +513,8 @@ ctsm.check.sex.biota <- function(data, info) {
 ctsm.check.unit.biota <- function(data, info) {
 
   standard_unit <- c(
-    "g/g", "mg/mg", "ug/ug", "ng/ng", "pg/pg", "mg/g", "ug/g", "ng/g", "pg/g", "g/kg", "mg/kg", 
-    "ug/kg", "ng/kg", "pg/kg")
+    "g/g", "mg/mg", "ug/ug", "ng/ng", "pg/pg", "mg/g", "ug/g", "ng/g", "pg/g", 
+    "g/kg", "mg/kg", "ug/kg", "ng/kg", "pg/kg")
   
   id <- ctsm_is_contaminant(data$pargroup, exclude = "I-RNC") & data$determinand != "TEQDFP"
   if (any(id))
@@ -559,6 +559,13 @@ ctsm.check.unit.biota <- function(data, info) {
   if (any(id))
     data[id,] <- within(data[id,], {
       ok <- unit %in% "y"
+      action <- ifelse(ok, "none", "error")
+    })
+  
+  id <- data$determinand %in% c("WTMEA")
+  if (any(id))
+    data[id,] <- within(data[id,], {
+      ok <- unit %in% c("kg", "g", "mg")
       action <- ifelse(ok, "none", "error")
     })
   
@@ -786,7 +793,7 @@ ctsm.check.value.biota <- function(data, info) {
   
   id <- ctsm_is_contaminant(data$pargroup, exclude = "I-MTC") | 
     data$group %in% "Metabolites" | 
-    data$determinand %in% c("EROD", "ALAD", "ACHE", "GST", "AGMEA", "LNMEA")
+    data$determinand %in% c("EROD", "ALAD", "ACHE", "GST", "AGMEA", "LNMEA", "WTMEA")
 
   if (any(id))
     data[id,] <- within(data[id,], {

--- a/man/read_data.Rd
+++ b/man/read_data.Rd
@@ -98,10 +98,37 @@ parameters that dictate the assessment process.
 \details{
 \subsection{Control parameters}{
 
-Many aspects of the assessment process can be controlled through the
-parameters stored in \code{info$control}. This is a list populated with default
-values which can then be overwritten, if required, using the \code{control}
-argument.
+Many aspects of the assessment process can be controlled using parameters
+which are stored in the \code{info} component of the harsat data object. The
+default control values can be overwritten using the \code{control} argument.
+\itemize{
+\item \code{reporting_window} A scalar (default 6) which determines whether
+timeseries are excluded because they have no 'recent' data. Formally,
+timeseries are excluded if they have no data in the period
+\code{max_year - reporting_window + 1} and \code{max_year}, so the default approach
+is to exclude timeseries if they have no dat in the most recent six
+monitoring years. The value of 6 is chosen to match with Marine Strategy
+Framework Directive reporting periods.
+\item \code{region}
+\item \code{add_stations}
+\item \code{bivalve_spawning_season}
+\item \code{use_stage}
+\item \code{relative_uncertainty}
+\item \code{auxiliary} A list which allows flexibility in the treatment of auxiliary
+variables. At present, there is just one component \code{by_matrix}, a
+character vector that determines which auxiliary variables are matched to
+the contaminant data by \code{sample} and \code{matrix} as opposed to just \code{sample}.
+For sediment and water, the default is \code{all}; i.e. all variables are
+matched by \code{sample} and \code{matrix}. This ensures, for example, that
+sediment normalisers such as aluminium and organic carbon content are
+matched to chemical measurements in the same grain fraction. For biota, the
+default is \verb{c("DRYWT\%", "LIPIDWT\%)}, so these variables are matched by
+\code{sample} and \code{matrix} and all other variables (e.g. LNMEA or \%FEMALEPOP)
+are matched by \code{sample}. Thus, dry weight and lipid weight contents are
+matched to chemical measurements in the same tissue. However, mean length
+(which is usually the lenght of the whole organism) is matched to all
+tissue types.
+}
 }
 
 \subsection{External data}{


### PR DESCRIPTION
#478 
The checks for valid sex codes for biota should now work for any auxiliary variable.  Most variables are just checked against valid ICES codes; imposex and EROD have more specific checks as before.
It will be a bigger job to ensure the other biota checks will work for any auxiliary variable. For now I have ensured they will work for WTMEA and AGMEA.  

#81 
A related issue is that 'new' auxiliary variables aren't necessarily merged with the data correctly.  Some auxiliary variables are merged by sample and matrix, whereas others are just merged by sample.  This was hard-wired and has now been made more flexible by introducing a new control variable `auxiliary`.  This is a list with (currently) just one element `by_matrix` which takes the default values `c("DRYWT%", "LIPIDWT%)` for biota and `"all"` for sediment and water.  The values can be modified with the `control` argument of `read_data`.  Thus, by default, dry weight and lipid weight measurements are matched with chemical concentrations in the same tissue (matrix). but all other auxiliary variables in biota are matched at the sample level.  For sediment (and water), all auxiliary variables (e.g. aluminium and organic carbon measurements) are matched with chemical concentrations in the same grain size fraction.  
There are still other elements that are hard wired in `merge_auxiliary` and these will be dealt with in a later pull request.
