### PR TITLE
Issue 409 report and graphics functionality for OSPAR 2024 assessment

### DIFF
--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -974,7 +974,10 @@ report_assessment <- function(
       
       output_id <- gsub(" \ ", " ", output_id, fixed = TRUE)
       output_id <- gsub("\\", " ", output_id, fixed = TRUE)
+
+      # and any % e.g. %DNATAIL!
       
+      output_id <- gsub("%", "", output_id, fixed = TRUE)
     }
           
     package_dir = system.file(package = "harsat")

--- a/inst/markdown/report_assessment.Rmd
+++ b/inst/markdown/report_assessment.Rmd
@@ -77,9 +77,10 @@ if (assessment_object$info$compartment == "biota") {
   group_id <- assessment_object$timeSeries[params$series, "detGroup"]
   if (!group_id  %in% c("Effects", "Imposex", "Metabolites"))
     var_id <- c(var_id, "matrix")
-  species_id <- assessment_object$timeSeries[params$series, "species"]
-  if (ctsm_get_info(assessment_object$info$species, species_id, "species_group") %in% "Mammal")
+  subseries_id <- assessment_object$timeSeries[params$series, "subseries"]
+  if (!is.na(subseries_id)) { 
     var_id <- c(var_id, "subseries")
+  }
 }
 
 assessment_object <- within(assessment_object, {
@@ -154,7 +155,12 @@ if (info$compartment %in% "biota") {
 if (info$compartment %in% "biota") {
   info$subseries <- gsub("_", " ", info$subseries)
   if (is.na(info$subseries)) {
-    info$subseries <- "all individuals"
+    info$subseries <- switch(
+      info$sex,
+      M = "males",
+      F = "females", 
+      NA_character_
+    )
   }
 }
 
@@ -339,17 +345,24 @@ info_multi <- within(info_multi, {
   names(determinand) <- seriesID
 })
 
-# get series names for labelling plots - usually just determinand, but could be more complex if e.g.
-# measured in multiple tissues, or when dealing with biological effects
+# get series names for labelling plots - usually just determinand, but could be more complex if 
+# e.g. dealing with biological effects - currently only works for EROD and males and females
 
 info_multi$plotNames <- with(info_multi, list(data = determinand, assessment = determinand))
 
 if (any(duplicated(info_multi$plotNames))) {
-  dups <- with(info_multi, duplicated(determinand) | duplicated(determinand, fromLast = TRUE))
-  info_multi$plotNames$data[dups] <- paste(
-    info_multi$determinand, assessment_object$timeSeries$level6name, sep = "\n")[dups]
-  info_multi$plotNames$assessment[dups] <- paste(
-    info_multi$determinand, assessment_object$timeSeries$level6name)[dups]
+  dups <- with(info_multi, duplicated(determinand) | duplicated(determinand, fromLast = TRUE)) 
+  if (info$compartment == "biota") {
+    sex_names <- dplyr::case_match(
+      assessment_object$timeSeries$sex, 
+      "M" ~ "males",
+      "F" ~ "females"
+    )
+    info_multi$plotNames$data[dups] <- paste(
+      info_multi$determinand, sex_names, sep = "\n")[dups]
+    info_multi$plotNames$assessment[dups] <- paste(
+      info_multi$determinand, sex_names)[dups]
+  }
   if (any(duplicated(info_multi$plotNames$data))) 
     cat("Error: duplicate plotting names - need to extend coding")
 }
@@ -394,7 +407,14 @@ is_ratio <- switch(
 intro_txt <- switch(
   info$compartment, 
   biota = paste(info$species_name, info$matrix_name), 
-  info$compartment
+  sediment = switch(
+    info$matrix, 
+    SEDTOT = "unsieved sediment",
+    SED63 = "sediment (< 63 micron fraction)",
+    SED20 = "sediment (< 20 micron fraction)",
+    paste0("sediment (", info$matrix, ")")
+  ),
+  water = paste(info$filtration, "water")
 )
 
 if (info$compartment %in% "biota" && info$species_group %in% "Mammal" && !is.na(info$subseries)) 
@@ -586,6 +606,11 @@ txt <- if (anova_ok) "Finally, the tab" else "The tab also"
 <li>OSPAR subregion: `r info$ospar_subregion`</li>
 <li>Station code: `r info$station_code`</li>
 <li>Station name: `r info$station_name`</li>
+
+```{asis, eval = !is.na(info$station_longname) && info$station_longname != info$station_name}
+<li>Station longname: `r info$station_longname`</li>
+```
+
 <li>Station latitude: `r format(info$station_latitude, digits = 2, nsmall = 2)`</li>
 <li class = "gap">Station longitude: `r format(info$station_longitude, digits = 2, nsmall = 2)`</li>
 <li>Compartment: `r info$compartment`</li>
@@ -595,7 +620,7 @@ txt <- if (anova_ok) "Finally, the tab" else "The tab also"
 <li>Species common name: `r info$species_name`</li>  
 ```
 
-```{asis, eval = info$compartment %in% "biota" && info$species_group %in% "Mammal" && !is.na(info$subseries)}
+```{asis, eval = info$compartment %in% "biota" && !is.na(info$subseries) && !info$determinand %in% "EROD"}
 <li>Sex / age group: `r tolower(info$subseries)`</li>
 ```
 
@@ -678,6 +703,9 @@ plot_auxiliary(data, assessment, info, assessment_object$info, auxiliary = auxil
 
 ```{r, include = FALSE}
 ok <- ! info$detGroup %in% "Imposex"
+if (info$determinand == "EROD") {
+  info_multi$subseries <- NA_character_
+}
 ```
 
 ```{asis, eval = !ok}


### PR DESCRIPTION
Resolves #409
Also mostly deals with #189
A lot of fiddly changes to ensure `plot_assessment` and `report_assessment` work for the OSPAR 2024 assessment.  This includes:

- key for water plots now shows whether the time series is filtered or unfiltered 
- multiplots now only show data or assessments from the same subseries (so e.g. if looking at metals in polar bears, the data and assessments for juveniles and adults will get plotted separately) 
- multiplots involving EROD now indicate which time series is for males and which is for females 

Extensively tested on OSPAR 2024 assessment objects.  Also tested on harsat example data sets.  

There is still work to do here.  For example, the labeling related to normalisation is hard-wired.  It is correct for the current OSPAR configuration.  It is correct for the current HELCOM configuration for sediment but not for biota.  And it won't respond to any user-specified normalisation requests.  This is related to #161, but will have to be dealt with after the next release.

Another request that I forsee will be e.g. to show multiplots for assessments of the same determinand but in different tissues or subseries.  Again, this will have to be dealt with after the next release.
