### PR TITLE
Bug in plot_assessment

### DIFF
--- a/R/graphics_functions.R
+++ b/R/graphics_functions.R
@@ -610,7 +610,7 @@ plot.AC <- function(AC, ylim, useLogs = TRUE) {
 
 plot_data <- function(
     data, assessment, series, info, type = c("data", "assessment"), 
-    xykey.cex = 1.0, ntick.x = 4, ntick.y = 3, newPage = TRUE, ...) {
+    xykey.cex = 1.0, ntick.x = 4, ntick.y = 3, ...) {
 
   # silence non-standard evaluation warnings
   .data <- year <- censoring <- NULL
@@ -656,7 +656,7 @@ plot_data <- function(
   
 
   # set up graphical structures
-    
+
   args.list <- list(data$concentration)         # NB have taken logs above, so this is log concentration
   
   if (is.pred) {
@@ -676,7 +676,7 @@ plot_data <- function(
   else {
     ylim <- c(do.call("plot.data.ylim", args.list))
   }
-    
+
   xlim <- plot.data.xlim(data$year, info$recent_years)
 
   plot.formula <- data$concentration ~ data$year
@@ -693,7 +693,7 @@ plot_data <- function(
   AC.width <- unit(0, "npc")
   if (is.AC) {
 
-    AC <- plot.AC(assessment$AC, ylim, useLogs)
+    AC <- plot.AC(assessment$AC, ylim, useLogs)  ## This throws a newPage
 
     # if (any(AC$ok))
     #   AC <- AC[AC$ok,]
@@ -826,7 +826,8 @@ plot_data <- function(
         ylabel, 0, unit(1, "npc") + unit(1.5, "char"), just = c("left", "bottom"), gp = gpar(cex = xykey.cex))
       upViewport()
     })
-
+  
+  newPage <- !is.AC
   plot.setup(newPage)
   pushViewport(viewport(layout.pos.row = 1))
   pushViewport(wk.viewport)

--- a/example_external_data.r
+++ b/example_external_data.r
@@ -101,7 +101,7 @@ write_summary_table(
 
 plot_assessment(
   biota_assessment,
-  subset = species %in% "Phoca hispida",
+  subset = species %in% "Globicephala melas",
   output_dir = file.path("output", "graphics"), 
   file_type = "data",
   file_format = "png"
@@ -117,7 +117,7 @@ plot_assessment(
 
 plot_assessment(
   biota_assessment,
-  subset = station_code %in% "A1",
+  subset = station_code %in% "A902",
   output_dir = file.path("output", "graphics"), 
   file_type = "data",
   file_format = "pdf"
@@ -125,7 +125,7 @@ plot_assessment(
 
 plot_assessment(
   biota_assessment, 
-  subset = series == "A1 HG Phoca hispida LI adult",
+  subset = series == "A902 PFOS Globicephala melas LI JV",
   output_dir = file.path("output", "graphics"), 
   file_format = "pdf"
 )


### PR DESCRIPTION
resolves #508

Small fix to ensure no extra page is produced when producing pdf output in `plot_assessment`.  An extra page was previously produced when there were assessment criteria and the function that calculated the placeholder for plotting the assessment criteria threw a new page (unexpectedly to me at least).

The fix is ad-hoc.  Some work on the code for setting up all the viewports would be beneficial, but low priority.  

Also updated the example file for external data (that can be used to test changes) so that it is compatible with the current external data set (i.e. change of species and station selected for plotting).