### PR TITLE
Column headers in write_summary_table

### DIFF
--- a/R/assessment_functions.R
+++ b/R/assessment_functions.R
@@ -1042,18 +1042,18 @@ assess_lmm <- function(
     
     if (output$method == "smooth") {
       
-      p_nonlinear <- with(output, {
+      p_nonlinear_trend <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["linear", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
       })
 
-      p_linear <- with(output, {
+      p_linear_trend <- with(output, {
         diff <- anova["linear", "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, 1, lower.tail = FALSE)
       })
 
-      p_total <- with(output, {
+      p_overall_trend <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
@@ -1063,19 +1063,19 @@ assess_lmm <- function(
       
     if (output$method == "linear") {
       
-      p_linear <- with(output, {
+      p_linear_trend <- with(output, {
         diff <- anova["linear", "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_total <- p_linear
+      p_overall_trend <- p_linear_trend
       
     }
     
     if (output$method %in% c("linear", "smooth")) {
       
       # p_overall_change
-      # method = "linear" use p_linear (from likelihood ratio test)  
+      # method = "linear" use p_linear_trend (from likelihood ratio test)  
       # method = "smooth" use p from the Wald test in contrasts 
       # for linear model, likelihood ratio test is a better test (fewer 
       #   approximations) than the Wald test
@@ -1083,18 +1083,18 @@ assess_lmm <- function(
       #   territory (future enhancement) 
       
       # p_recent_change
-      # same approach; however p_linear could be misleading when the years at 
+      # same approach; however p_linear_trend could be misleading when the years at 
       #   the end of the time series are all censored values and a flat model is 
-      #   fitted; the estimate of recent_change is shrunk to reflect this, but p_linear 
-      #   might be misleadingly significant; something to think about in the 
-      #   future
+      #   fitted; the estimate of recent_change is shrunk to reflect this, but 
+      #   p_linear_trend might be misleadingly significant; something to think 
+      #   about in the future
       # however, there is a pathological case when all the fitted values in the 
       #   recent period have the same value; recent_change is zero, and yet can still be 
-      #   significant based on p_linear even though there are no data to support 
+      #   significant based on p_linear_trend even though there are no data to support 
       #   this; in this case use p from the Wald test (which is unity)
       
       if (output$method == "linear") {
-        p_overall_change <- p_linear
+        p_overall_change <- p_linear_trend
       } else {
         p_overall_change <- output$contrasts["whole", "p"]
       }
@@ -1107,7 +1107,7 @@ assess_lmm <- function(
           output$method == "linear" & 
           max(data$year[data$censoring %in% ""]) > start_recent
         ) {
-          p_recent_change <- p_linear
+          p_recent_change <- p_linear_trend
         } else {
           p_recent_change <- output$contrasts["recent", "p"]
         }          
@@ -1217,9 +1217,9 @@ assess_lmm <- function(
   
     # and round for ease of interpretation
     
-    p_nonlinear <- round(p_nonlinear, 4)
-    p_linear <- round(p_linear, 4)
-    p_total <- round(p_total, 4)
+    p_nonlinear_trend <- round(p_nonlinear_trend, 4)
+    p_linear_trend <- round(p_linear_trend, 4)
+    p_overall_trend <- round(p_overall_trend, 4)
     p_overall_change <- round(p_overall_change, 4)
     p_recent_change <- round(p_recent_change, 4)
     
@@ -1703,9 +1703,9 @@ initialise_assessment_summary <- function(
     firstYearAll = firstYearAll, 
     firstYearFit = min(year), 
     lastyear = max(year),
-    p_nonlinear = NA_real_, 
-    p_linear = NA_real_, 
-    p_total = NA_real_, 
+    p_nonlinear_trend = NA_real_, 
+    p_linear_trend = NA_real_, 
+    p_overall_trend = NA_real_, 
     p_overall_change = NA_real_, 
     overall_change = NA_real_, 
     p_recent_change = NA_real_, 
@@ -2076,18 +2076,18 @@ assess_survival <- function(
     
     if (output$method == "smooth") {
       
-      p_nonlinear <- with(output, {
+      p_nonlinear_trend <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["linear", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
       })
       
-      p_linear <- with(output, {
+      p_linear_trend <- with(output, {
         diff <- anova["linear", "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_total <- with(output, {
+      p_overall_trend <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
@@ -2097,12 +2097,12 @@ assess_survival <- function(
     
     if (output$method == "linear") {
       
-      p_linear <- with(output, {
+      p_linear_trend <- with(output, {
         diff <- anova["linear", "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_total <- p_linear
+      p_overall_trend <- p_linear_trend
       
     }
     
@@ -2113,7 +2113,7 @@ assess_survival <- function(
       # really need to go into profile likelihood territory here!
       
       p_overall_change <- if (output$method == "linear") {
-        p_linear
+        p_linear_trend
       } else {
         output$contrasts["whole", "p"]
       }
@@ -2122,7 +2122,7 @@ assess_survival <- function(
       
       if ("recent" %in% row.names(output$contrasts)) {
         p_recent_change <- if (output$method == "linear") {
-          p_linear
+          p_linear_trend
         } else {
           with(output$contrasts["recent", ], p)
         }
@@ -2195,9 +2195,9 @@ assess_survival <- function(
     
     # and round for ease of interpretation
     
-    p_nonlinear <- round(p_nonlinear, 4)
-    p_linear <- round(p_linear, 4)
-    p_total <- round(p_total, 4)
+    p_nonlinear_trend <- round(p_nonlinear_trend, 4)
+    p_linear_trend <- round(p_linear_trend, 4)
+    p_overall_trend <- round(p_overall_trend, 4)
     p_overall_change <- round(p_overall_change, 4)
     p_recent_change <- round(p_recent_change, 4)
     
@@ -2539,18 +2539,18 @@ assess_beta <- function(
     
     if (output$method == "smooth") {
       
-      p_nonlinear <- with(output, {
+      p_nonlinear_trend <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["linear", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
       })
       
-      p_linear <- with(output, {
+      p_linear_trend <- with(output, {
         diff <- anova["linear", "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_total <- with(output, {
+      p_overall_trend <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
@@ -2560,12 +2560,12 @@ assess_beta <- function(
     
     if (output$method == "linear") {
       
-      p_linear <- with(output, {
+      p_linear_trend <- with(output, {
         diff <- anova["linear", "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_total <- p_linear
+      p_overall_trend <- p_linear_trend
       
     }
     
@@ -2576,7 +2576,7 @@ assess_beta <- function(
       # really need to go into profile likelihood territory here!
       
       p_overall_change <- if (output$method == "linear") {
-        p_linear
+        p_linear_trend
       } else {
         output$contrasts["whole", "p"]
       }
@@ -2585,7 +2585,7 @@ assess_beta <- function(
       
       if ("recent" %in% row.names(output$contrasts)) {
         p_recent_change <- if (output$method == "linear") {
-          p_linear
+          p_linear_trend
         } else {
           with(output$contrasts["recent", ], p)
         }
@@ -2672,9 +2672,9 @@ assess_beta <- function(
     
     # and round for ease of interpretation
     
-    p_nonlinear <- round(p_nonlinear, 4)
-    p_linear <- round(p_linear, 4)
-    p_total <- round(p_total, 4)
+    p_nonlinear_trend <- round(p_nonlinear_trend, 4)
+    p_linear_trend <- round(p_linear_trend, 4)
+    p_overall_trend <- round(p_overall_trend, 4)
     p_overall_change <- round(p_overall_change, 4)
     p_recent_change <- round(p_recent_change, 4)
     
@@ -2940,18 +2940,18 @@ assess_negativebinomial <- function(
     
     if (output$method == "smooth") {
       
-      p_nonlinear <- with(output, {
+      p_nonlinear_trend <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["linear", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
       })
       
-      p_linear <- with(output, {
+      p_linear_trend <- with(output, {
         diff <- anova["linear", "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_total <- with(output, {
+      p_overall_trend <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
@@ -2961,12 +2961,12 @@ assess_negativebinomial <- function(
     
     if (output$method == "linear") {
       
-      p_linear <- with(output, {
+      p_linear_trend <- with(output, {
         diff <- anova["linear", "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_total <- p_linear
+      p_overall_trend <- p_linear_trend
       
     }
     
@@ -2977,7 +2977,7 @@ assess_negativebinomial <- function(
       # really need to go into profile likelihood territory here!
       
       p_overall_change <- if (output$method == "linear") {
-        p_linear
+        p_linear_trend
       } else {
         output$contrasts["whole", "p"]
       }
@@ -2986,7 +2986,7 @@ assess_negativebinomial <- function(
       
       if ("recent" %in% row.names(output$contrasts)) {
         p_recent_change <- if (output$method == "linear") {
-          p_linear
+          p_linear_trend
         } else {
           with(output$contrasts["recent", ], p)
         }
@@ -3079,9 +3079,9 @@ assess_negativebinomial <- function(
     
     # and round for ease of interpretation
     
-    p_nonlinear <- round(p_nonlinear, 4)
-    p_linear <- round(p_linear, 4)
-    p_total <- round(p_total, 4)
+    p_nonlinear_trend <- round(p_nonlinear_trend, 4)
+    p_linear_trend <- round(p_linear_trend, 4)
+    p_overall_trend <- round(p_overall_trend, 4)
     p_overall_change <- round(p_overall_change, 4)
     p_recent_change <- round(p_recent_change, 4)
     

--- a/R/assessment_functions.R
+++ b/R/assessment_functions.R
@@ -1053,7 +1053,7 @@ assess_lmm <- function(
         pchisq(diff, 1, lower.tail = FALSE)
       })
 
-      p_overall <- with(output, {
+      p_total <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
@@ -1068,13 +1068,13 @@ assess_lmm <- function(
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_overall <- p_linear
+      p_total <- p_linear
       
     }
     
     if (output$method %in% c("linear", "smooth")) {
       
-      # pltrend
+      # p_overall_change
       # method = "linear" use p_linear (from likelihood ratio test)  
       # method = "smooth" use p from the Wald test in contrasts 
       # for linear model, likelihood ratio test is a better test (fewer 
@@ -1082,24 +1082,24 @@ assess_lmm <- function(
       # for smooth model, would be better to go into profile likelihood 
       #   territory (future enhancement) 
       
-      # prtrend
+      # p_recent_change
       # same approach; however p_linear could be misleading when the years at 
       #   the end of the time series are all censored values and a flat model is 
-      #   fitted; the estimate of rtrend is shrunk to reflect this, but p_linear 
+      #   fitted; the estimate of recent_change is shrunk to reflect this, but p_linear 
       #   might be misleadingly significant; something to think about in the 
       #   future
       # however, there is a pathological case when all the fitted values in the 
-      #   recent period have the same value; rtrend is zero, and yet can still be 
+      #   recent period have the same value; recent_change is zero, and yet can still be 
       #   significant based on p_linear even though there are no data to support 
       #   this; in this case use p from the Wald test (which is unity)
       
       if (output$method == "linear") {
-        pltrend <- p_linear
+        p_overall_change <- p_linear
       } else {
-        pltrend <- output$contrasts["whole", "p"]
+        p_overall_change <- output$contrasts["whole", "p"]
       }
       
-      ltrend <- with(output$contrasts["whole", ], estimate / (end - start))
+      overall_change <- with(output$contrasts["whole", ], estimate / (end - start))
       
       if ("recent" %in% row.names(output$contrasts)) {
         
@@ -1107,12 +1107,12 @@ assess_lmm <- function(
           output$method == "linear" & 
           max(data$year[data$censoring %in% ""]) > start_recent
         ) {
-          prtrend <- p_linear
+          p_recent_change <- p_linear
         } else {
-          prtrend <- output$contrasts["recent", "p"]
+          p_recent_change <- output$contrasts["recent", "p"]
         }          
 
-        rtrend <- with(output$contrasts["recent", ], estimate / (end - start))
+        recent_change <- with(output$contrasts["recent", ], estimate / (end - start))
       }
     }
                               
@@ -1147,8 +1147,8 @@ assess_lmm <- function(
     # backtransform for log-normal distribution (and to give percentage trends)
     
     if (distribution == "lognormal") {
-      ltrend <- ltrend * 100
-      rtrend <- rtrend * 100
+      overall_change <- overall_change * 100
+      recent_change <- recent_change * 100
       dtrend <- dtrend * 100
       meanLY <- exp(meanLY)
       clLY <- exp(clLY)
@@ -1162,7 +1162,7 @@ assess_lmm <- function(
       value <- AC[i]
       diff <- with(output, if (method == "none") summary$meanLY - value else summary$clLY - value)
       
-      # estimate number of years until meanLY reaches target - based on rtrend
+      # estimate number of years until meanLY reaches target - based on recent_change
       # might be already there but cl is too high
       
       maxYear <- max(data$year)
@@ -1172,34 +1172,34 @@ assess_lmm <- function(
         
         if (good.status == "low") {
         
-          if (is.na(value) || (meanLY >= value & is.na(rtrend)))
+          if (is.na(value) || (meanLY >= value & is.na(recent_change)))
             NA
           else if (meanLY < value) 
             maxYear
-          else if (rtrend >= 0)
+          else if (recent_change >= 0)
             bigYear
           else {
             wk <- switch(
               distribution, 
-              lognormal = 100 * (log(value) - log(meanLY)) / rtrend,
-              (value - meanLY) / rtrend)
+              lognormal = 100 * (log(value) - log(meanLY)) / recent_change,
+              (value - meanLY) / recent_change)
             wk <- round(wk + maxYear)
             min(wk, bigYear)
           }
           
         } else {
           
-          if (is.na(value) || (meanLY <= value & is.na(rtrend)))
+          if (is.na(value) || (meanLY <= value & is.na(recent_change)))
             NA
           else if (meanLY > value) 
             maxYear
-          else if (rtrend <= 0)
+          else if (recent_change <= 0)
             bigYear
           else {
             wk <- switch(
               distribution, 
-              lognormal = 100 * (log(value) - log(meanLY)) / rtrend,
-              (value - meanLY) / rtrend)
+              lognormal = 100 * (log(value) - log(meanLY)) / recent_change,
+              (value - meanLY) / recent_change)
             wk <- round(wk + maxYear)
             min(wk, bigYear)
           }
@@ -1219,12 +1219,12 @@ assess_lmm <- function(
     
     p_nonlinear <- round(p_nonlinear, 4)
     p_linear <- round(p_linear, 4)
-    p_overall <- round(p_overall, 4)
-    pltrend <- round(pltrend, 4)
-    prtrend <- round(prtrend, 4)
+    p_total <- round(p_total, 4)
+    p_overall_change <- round(p_overall_change, 4)
+    p_recent_change <- round(p_recent_change, 4)
     
-    ltrend <- round(ltrend, 1)
-    rtrend <- round(rtrend, 1)
+    overall_change <- round(overall_change, 1)
+    recent_change <- round(recent_change, 1)
     dtrend <- round(dtrend, 1)
   })
   
@@ -1705,11 +1705,11 @@ initialise_assessment_summary <- function(
     lastyear = max(year),
     p_nonlinear = NA_real_, 
     p_linear = NA_real_, 
-    p_overall = NA_real_, 
-    pltrend = NA_real_, 
-    ltrend = NA_real_, 
-    prtrend = NA_real_, 
-    rtrend = NA_real_, 
+    p_total = NA_real_, 
+    p_overall_change = NA_real_, 
+    overall_change = NA_real_, 
+    p_recent_change = NA_real_, 
+    recent_change = NA_real_, 
     dtrend = NA_real_, 
     meanLY = NA_real_, 
     clLY = NA_real_ 
@@ -2087,7 +2087,7 @@ assess_survival <- function(
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_overall <- with(output, {
+      p_total <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
@@ -2102,31 +2102,31 @@ assess_survival <- function(
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_overall <- p_linear
+      p_total <- p_linear
       
     }
     
     if (output$method %in% c("linear", "smooth")) {
       
-      # for linear trend and recent trend, use pltrend (from likelihood ratio test) if 
-      # method = "linear", because a better test 
+      # for linear trend and recent trend, use p_overall_change (from likelihood 
+      # ratio test) if method = "linear", because a better test 
       # really need to go into profile likelihood territory here!
       
-      pltrend <- if (output$method == "linear") {
+      p_overall_change <- if (output$method == "linear") {
         p_linear
       } else {
         output$contrasts["whole", "p"]
       }
       
-      ltrend <- with(output$contrasts["whole", ], estimate / (end - start))
+      overall_change <- with(output$contrasts["whole", ], estimate / (end - start))
       
       if ("recent" %in% row.names(output$contrasts)) {
-        prtrend <- if (output$method == "linear") {
+        p_recent_change <- if (output$method == "linear") {
           p_linear
         } else {
           with(output$contrasts["recent", ], p)
         }
-        rtrend <- with(output$contrasts["recent", ], estimate / (end - start))
+        recent_change <- with(output$contrasts["recent", ], estimate / (end - start))
       }
     }
     
@@ -2154,8 +2154,8 @@ assess_survival <- function(
     
     # turn trends into 'percentage trends'
     
-    ltrend <- ltrend * 100
-    rtrend <- rtrend * 100
+    overall_change <- overall_change * 100
+    recent_change <- recent_change * 100
   })  
   
   if (!is.null(AC)) {
@@ -2164,7 +2164,7 @@ assess_survival <- function(
       value <- AC[i]
       diff <- with(output, if (method == "none") summary$meanLY - value else summary$clLY - value)
       
-      # estimate number of years until meanLY reaches target - based on rtrend
+      # estimate number of years until meanLY reaches target - based on recent_change
       # might be already there but cl is too high
       
       maxYear <- max(data$year)
@@ -2172,14 +2172,14 @@ assess_survival <- function(
       
       tillTarget <- with(output$summary, {
         
-        if (is.na(value) || (meanLY <= value & is.na(rtrend)))
+        if (is.na(value) || (meanLY <= value & is.na(recent_change)))
           NA
         else if (meanLY >= value) 
           maxYear
-        else if (rtrend <= 0)
+        else if (recent_change <= 0)
           bigYear
         else {
-          wk <- 100 * (log(value) - log(meanLY)) / rtrend
+          wk <- 100 * (log(value) - log(meanLY)) / recent_change
           wk <- round(wk + maxYear)
           min(wk, bigYear)
         }
@@ -2197,12 +2197,12 @@ assess_survival <- function(
     
     p_nonlinear <- round(p_nonlinear, 4)
     p_linear <- round(p_linear, 4)
-    p_overall <- round(p_overall, 4)
-    pltrend <- round(pltrend, 4)
-    prtrend <- round(prtrend, 4)
+    p_total <- round(p_total, 4)
+    p_overall_change <- round(p_overall_change, 4)
+    p_recent_change <- round(p_recent_change, 4)
     
-    ltrend <- round(ltrend, 1)
-    rtrend <- round(rtrend, 1)
+    overall_change <- round(overall_change, 1)
+    recent_change <- round(recent_change, 1)
     dtrend <- round(dtrend, 1)
   })
   
@@ -2550,7 +2550,7 @@ assess_beta <- function(
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_overall <- with(output, {
+      p_total <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
@@ -2565,31 +2565,31 @@ assess_beta <- function(
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_overall <- p_linear
+      p_total <- p_linear
       
     }
     
     if (output$method %in% c("linear", "smooth")) {
       
-      # for linear trend and recent trend, use pltrend (from likelihood ratio test) if 
-      # method = "linear", because a better test 
+      # for linear trend and recent trend, use p_overall_change (from likelihood 
+      # ratio test) if method = "linear", because a better test 
       # really need to go into profile likelihood territory here!
       
-      pltrend <- if (output$method == "linear") {
+      p_overall_change <- if (output$method == "linear") {
         p_linear
       } else {
         output$contrasts["whole", "p"]
       }
       
-      ltrend <- with(output$contrasts["whole", ], estimate / (end - start))
+      overall_change <- with(output$contrasts["whole", ], estimate / (end - start))
       
       if ("recent" %in% row.names(output$contrasts)) {
-        prtrend <- if (output$method == "linear") {
+        p_recent_change <- if (output$method == "linear") {
           p_linear
         } else {
           with(output$contrasts["recent", ], p)
         }
-        rtrend <- with(output$contrasts["recent", ], estimate / (end - start))
+        recent_change <- with(output$contrasts["recent", ], estimate / (end - start))
       }
     }
     
@@ -2623,7 +2623,7 @@ assess_beta <- function(
       value <- AC[i]
       diff <- with(output, if (method == "none") summary$meanLY - value else summary$clLY - value)
       
-      # estimate number of years until meanLY reaches target - based on rtrend
+      # estimate number of years until meanLY reaches target - based on recent_change
       # might be already there but cl is too high
       
       maxYear <- max(data$year)
@@ -2633,28 +2633,28 @@ assess_beta <- function(
         
         if (good_status == "low") {
           
-          if (is.na(value) || (meanLY >= value & is.na(rtrend)))
+          if (is.na(value) || (meanLY >= value & is.na(recent_change)))
             NA
           else if (meanLY < value) 
             maxYear
-          else if (rtrend >= 0)
+          else if (recent_change >= 0)
             bigYear
           else {
-            wk <- (qlogis(value / 100) - qlogis(meanLY / 100)) / rtrend
+            wk <- (qlogis(value / 100) - qlogis(meanLY / 100)) / recent_change
             wk <- round(wk + maxYear)
             min(wk, bigYear)
           }
           
         } else {
           
-          if (is.na(value) || (meanLY <= value & is.na(rtrend)))
+          if (is.na(value) || (meanLY <= value & is.na(recent_change)))
             NA
           else if (meanLY > value) 
             maxYear
-          else if (rtrend <= 0)
+          else if (recent_change <= 0)
             bigYear
           else {
-            wk <- (qlogis(value / 100) - qlogis(meanLY / 100)) / rtrend
+            wk <- (qlogis(value / 100) - qlogis(meanLY / 100)) / recent_change
             wk <- round(wk + maxYear)
             min(wk, bigYear)
           }
@@ -2674,12 +2674,12 @@ assess_beta <- function(
     
     p_nonlinear <- round(p_nonlinear, 4)
     p_linear <- round(p_linear, 4)
-    p_overall <- round(p_overall, 4)
-    pltrend <- round(pltrend, 4)
-    prtrend <- round(prtrend, 4)
+    p_total <- round(p_total, 4)
+    p_overall_change <- round(p_overall_change, 4)
+    p_recent_change <- round(p_recent_change, 4)
     
-    ltrend <- round(ltrend, 3)
-    rtrend <- round(rtrend, 3)
+    overall_change <- round(overall_change, 3)
+    recent_change <- round(recent_change, 3)
     dtrend <- round(dtrend, 3)
   })
   
@@ -2951,7 +2951,7 @@ assess_negativebinomial <- function(
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_overall <- with(output, {
+      p_total <- with(output, {
         smoothID <- paste0("smooth (df = ", dfSmooth, ")")
         diff <- anova[smoothID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
         pchisq(diff, dfSmooth - 1, lower.tail = FALSE)
@@ -2966,31 +2966,31 @@ assess_negativebinomial <- function(
         pchisq(diff, 1, lower.tail = FALSE)
       })
       
-      p_overall <- p_linear
+      p_total <- p_linear
       
     }
     
     if (output$method %in% c("linear", "smooth")) {
       
-      # for linear trend and recent trend, use pltrend (from likelihood ratio test) if 
-      # method = "linear", because a better test 
+      # for linear trend and recent trend, use p_overall_change (from likelihood 
+      # ratio test) if method = "linear", because a better test 
       # really need to go into profile likelihood territory here!
       
-      pltrend <- if (output$method == "linear") {
+      p_overall_change <- if (output$method == "linear") {
         p_linear
       } else {
         output$contrasts["whole", "p"]
       }
       
-      ltrend <- with(output$contrasts["whole", ], estimate / (end - start))
+      overall_change <- with(output$contrasts["whole", ], estimate / (end - start))
       
       if ("recent" %in% row.names(output$contrasts)) {
-        prtrend <- if (output$method == "linear") {
+        p_recent_change <- if (output$method == "linear") {
           p_linear
         } else {
           with(output$contrasts["recent", ], p)
         }
-        rtrend <- with(output$contrasts["recent", ], estimate / (end - start))
+        recent_change <- with(output$contrasts["recent", ], estimate / (end - start))
       }
     }
     
@@ -3019,8 +3019,8 @@ assess_negativebinomial <- function(
     
     # turn trends into 'percentage trends'
     
-    ltrend <- ltrend * 100
-    rtrend <- rtrend * 100
+    overall_change <- overall_change * 100
+    recent_change <- recent_change * 100
     
   })  
   
@@ -3030,7 +3030,7 @@ assess_negativebinomial <- function(
       value <- AC[i]
       diff <- with(output, if (method == "none") summary$meanLY - value else summary$clLY - value)
       
-      # estimate number of years until meanLY reaches target - based on rtrend
+      # estimate number of years until meanLY reaches target - based on recent_change
       # might be already there but cl is too high
       
       maxYear <- max(data$year)
@@ -3040,28 +3040,28 @@ assess_negativebinomial <- function(
         
         if (good_status == "low") {
           
-          if (is.na(value) || (meanLY >= value & is.na(rtrend)))
+          if (is.na(value) || (meanLY >= value & is.na(recent_change)))
             NA
           else if (meanLY < value) 
             maxYear
-          else if (rtrend >= 0)
+          else if (recent_change >= 0)
             bigYear
           else {
-            wk <- (exp(value) - exp(meanLY)) / rtrend
+            wk <- (exp(value) - exp(meanLY)) / recent_change
             wk <- round(wk + maxYear)
             min(wk, bigYear)
           }
           
         } else {
           
-          if (is.na(value) || (meanLY <= value & is.na(rtrend)))
+          if (is.na(value) || (meanLY <= value & is.na(recent_change)))
             NA
           else if (meanLY > value) 
             maxYear
-          else if (rtrend <= 0)
+          else if (recent_change <= 0)
             bigYear
           else {
-            wk <- (exp(value) - exp(meanLY)) / rtrend
+            wk <- (exp(value) - exp(meanLY)) / recent_change
             wk <- round(wk + maxYear)
             min(wk, bigYear)
           }
@@ -3081,12 +3081,12 @@ assess_negativebinomial <- function(
     
     p_nonlinear <- round(p_nonlinear, 4)
     p_linear <- round(p_linear, 4)
-    p_overall <- round(p_overall, 4)
-    pltrend <- round(pltrend, 4)
-    prtrend <- round(prtrend, 4)
+    p_total <- round(p_total, 4)
+    p_overall_change <- round(p_overall_change, 4)
+    p_recent_change <- round(p_recent_change, 4)
     
-    ltrend <- round(ltrend, 1)
-    rtrend <- round(rtrend, 1)
+    overall_change <- round(overall_change, 1)
+    recent_change <- round(recent_change, 1)
     dtrend <- round(dtrend, 1)
   })
   

--- a/R/imposex_clm.R
+++ b/R/imposex_clm.R
@@ -467,7 +467,7 @@ imposex_assess_clm <- function(
 
   linID <- switch(best.id[1], linear = "linear", smooth = "linear", paste(best.id[1], "mean linear"))
 
-  summary$p_linear <- summary$p_total <- with(fit, {
+  summary$p_linear_trend <- summary$p_overall_trend <- with(fit, {
     diff.lik <- anova[linID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
     dfFixed <- 1
     Fstat <- (diff.lik / dfFixed) / disp
@@ -477,14 +477,14 @@ imposex_assess_clm <- function(
   
   if (grepl("smooth", bestFit)) {
   
-    summary$p_nonlinear <- with(fit, {
+    summary$p_nonlinear_trend <- with(fit, {
       diff.lik <- twiceLogLik - anova[linID, "twiceLogLik"]
       dfFixed <- pFixed - 2
       Fstat <- (diff.lik / dfFixed) / disp
       pf(Fstat, dfFixed, dfResid, lower.tail = FALSE)
     })
     
-    summary$p_total <- with(fit, {
+    summary$p_overall_trend <- with(fit, {
       diff.lik <- twiceLogLik - anova["mean", "twiceLogLik"]
       dfFixed <- pFixed - 1
       Fstat <- (diff.lik / dfFixed) / disp
@@ -502,7 +502,7 @@ imposex_assess_clm <- function(
   # really need to go into profile likelihood territory here!
        
   if (grepl("linear", bestFit)) 
-    summary$p_overall_change <- summary$p_recent_change <- summary$p_linear    
+    summary$p_overall_change <- summary$p_recent_change <- summary$p_linear_trend    
   else {
     summary$p_overall_change <- output$contrasts["whole", "p"]
     summary$p_recent_change <- output$contrasts["recent", "p"]
@@ -519,9 +519,9 @@ imposex_assess_clm <- function(
     # round for ease of interpretation
     
     if (grepl("smooth", bestFit))
-      p_nonlinear <- round(p_nonlinear, 4)
-    p_linear <- round(p_linear, 4)
-    p_total <- round(p_total, 4)
+      p_nonlinear_trend <- round(p_nonlinear_trend, 4)
+    p_linear_trend <- round(p_linear_trend, 4)
+    p_overall_trend <- round(p_overall_trend, 4)
 
     p_overall_change <- round(p_overall_change, 4)
     p_recent_change <- round(p_recent_change, 4)

--- a/R/imposex_clm.R
+++ b/R/imposex_clm.R
@@ -467,7 +467,7 @@ imposex_assess_clm <- function(
 
   linID <- switch(best.id[1], linear = "linear", smooth = "linear", paste(best.id[1], "mean linear"))
 
-  summary$p_linear <- summary$p_overall <- with(fit, {
+  summary$p_linear <- summary$p_total <- with(fit, {
     diff.lik <- anova[linID, "twiceLogLik"] - anova["mean", "twiceLogLik"]
     dfFixed <- 1
     Fstat <- (diff.lik / dfFixed) / disp
@@ -484,7 +484,7 @@ imposex_assess_clm <- function(
       pf(Fstat, dfFixed, dfResid, lower.tail = FALSE)
     })
     
-    summary$p_overall <- with(fit, {
+    summary$p_total <- with(fit, {
       diff.lik <- twiceLogLik - anova["mean", "twiceLogLik"]
       dfFixed <- pFixed - 1
       Fstat <- (diff.lik / dfFixed) / disp
@@ -495,19 +495,20 @@ imposex_assess_clm <- function(
       
 
 
-  summary$ltrend <- with(output$contrasts["whole", ], estimate / (end - start))
+  summary$overall_change <- with(output$contrasts["whole", ], estimate / (end - start))
        
-  # for trends, use pltrend (from likelihood ratio test) if method is linear or changepoint linear, 
-  # because a better test - really need to go into profile likelihood territory here!
+  # for trends, use p_overall_change (from likelihood ratio test) if method is 
+  # linear or changepoint linear because a better test
+  # really need to go into profile likelihood territory here!
        
   if (grepl("linear", bestFit)) 
-    summary$pltrend <- summary$prtrend <- summary$p_linear    
+    summary$p_overall_change <- summary$p_recent_change <- summary$p_linear    
   else {
-    summary$pltrend <- output$contrasts["whole", "p"]
-    summary$prtrend <- output$contrasts["recent", "p"]
+    summary$p_overall_change <- output$contrasts["whole", "p"]
+    summary$p_recent_change <- output$contrasts["recent", "p"]
   }
   
-  summary$rtrend <- with(output$contrasts["recent", ], estimate / (end - start))
+  summary$recent_change <- with(output$contrasts["recent", ], estimate / (end - start))
 
   summary$meanLY <- tail(output$pred$fit, 1)
   summary$clLY <- tail(output$pred$ci.upper, 1)
@@ -520,13 +521,13 @@ imposex_assess_clm <- function(
     if (grepl("smooth", bestFit))
       p_nonlinear <- round(p_nonlinear, 4)
     p_linear <- round(p_linear, 4)
-    p_overall <- round(p_overall, 4)
+    p_total <- round(p_total, 4)
 
-    pltrend <- round(pltrend, 4)
-    prtrend <- round(prtrend, 4)
+    p_overall_change <- round(p_overall_change, 4)
+    p_recent_change <- round(p_recent_change, 4)
     
-    ltrend <- round(ltrend, 4)
-    rtrend <- round(rtrend, 4)
+    overall_change <- round(overall_change, 4)
+    recent_change <- round(recent_change, 4)
   })
   
 

--- a/R/imposex_functions.R
+++ b/R/imposex_functions.R
@@ -360,8 +360,8 @@ imposex.assess.index <- function(annualIndex, species, determinand, info.imposex
 
   if (diff(range(value)) == 0) {
     if (nYear > 3) {
-      summary$p_linear <- summary$p_total <- summary$p_overall_change <- 
-        summary$p_recent_change <- 1
+      summary$p_linear_trend <- summary$p_overall_trend <- 
+        summary$p_overall_change <- summary$p_recent_change <- 1
       summary$overall_change <- summary$recent_change <- 0
     }
     summary$meanLY <- value[1]
@@ -433,8 +433,8 @@ imposex.assess.index <- function(annualIndex, species, determinand, info.imposex
   output$pred <- data.frame(year = new.year, pred[c("fit", "ci.lower", "ci.upper")])
   
   if (nYear > 3) {
-    summary$p_linear <- summary$p_total <- summary$p_overall_change <- 
-      summary$p_recent_change <- 
+    summary$p_linear_trend <- summary$p_overall_trend <- 
+      summary$p_overall_change <- summary$p_recent_change <- 
       round(output$coefficients["year", "Pr(>|t|)"], 4)
     summary$overall_change <- summary$recent_change <- 
       round(output$coefficients["year", "Estimate"], 4)

--- a/R/imposex_functions.R
+++ b/R/imposex_functions.R
@@ -360,8 +360,9 @@ imposex.assess.index <- function(annualIndex, species, determinand, info.imposex
 
   if (diff(range(value)) == 0) {
     if (nYear > 3) {
-      summary$p_linear <- summary$p_overall <- summary$pltrend <- summary$prtrend <- 1
-      summary$ltrend <- summary$rtrend <- 0
+      summary$p_linear <- summary$p_total <- summary$p_overall_change <- 
+        summary$p_recent_change <- 1
+      summary$overall_change <- summary$recent_change <- 0
     }
     summary$meanLY <- value[1]
     summary$clLY <- value[1]
@@ -432,9 +433,11 @@ imposex.assess.index <- function(annualIndex, species, determinand, info.imposex
   output$pred <- data.frame(year = new.year, pred[c("fit", "ci.lower", "ci.upper")])
   
   if (nYear > 3) {
-    summary$p_linear <- summary$p_overall <- summary$pltrend <- summary$prtrend <- 
+    summary$p_linear <- summary$p_total <- summary$p_overall_change <- 
+      summary$p_recent_change <- 
       round(output$coefficients["year", "Pr(>|t|)"], 4)
-    summary$ltrend <- summary$rtrend <- round(output$coefficients["year", "Estimate"], 4)
+    summary$overall_change <- summary$recent_change <- 
+      round(output$coefficients["year", "Estimate"], 4)
   }
   summary$meanLY <- round(tail(pred$fit, 1), 3)
   summary$clLY <- round(tail(pred$ci.upper, 1), 3)

--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -184,20 +184,22 @@ ctsm_symbology_OSPAR <- function(summary, info, timeSeries, symbology, alpha = 0
     
     shape <- character(nrow(summary))
     
-    # trend symbols: a trend is estimated if pltrend is present - default shape is a large filled circle
+    # trend symbols 
+    # a trend is estimated if p_overall_change is present 
+    # default shape is a large filled circle
     
-    trendFit <- !is.na(pltrend)
+    trendFit <- !is.na(p_overall_change)
     shape[trendFit] <- "large_filled_circle"
     
-    # show a significant trend based on prtrend 
-    # NB prtrend might not exist even if pltrend does, because there are too few years of data in the
-    # recent window
+    # show a significant trend based on p_recent_change 
+    # note p_recent_change might not exist even if p_overall_change does, because 
+    # there are too few years of data in the recent window
     
     # isImposex <- timeSeries$detGroup %in% "Imposex"
     
-    isTrend <- !is.na(prtrend) & prtrend < alpha
-    upTrend <- isTrend & rtrend > 0
-    downTrend <- isTrend & rtrend < 0
+    isTrend <- !is.na(p_recent_change) & p_recent_change < alpha
+    upTrend <- isTrend & recent_change > 0
+    downTrend <- isTrend & recent_change < 0
     
     shape[downTrend] <- "downward_triangle"
     shape[upTrend] <- "upward_triangle"
@@ -669,10 +671,6 @@ write_summary_table <- function(
     first_year_all = "firstYearAll",
     first_year_fit = "firstYearFit",
     last_year = "lastyear",
-    p_linear_trend = "pltrend",
-    linear_trend = "ltrend",
-    p_recent_trend = "prtrend",
-    recent_trend = "rtrend",
     detectable_trend = "dtrend",
     mean_last_year = "meanLY",
     climit_last_year = "clLY"

--- a/inst/markdown/report_assessment.Rmd
+++ b/inst/markdown/report_assessment.Rmd
@@ -910,15 +910,15 @@ change_txt <- function(type = c("whole", "recent")) {
 }
 
 
-if (wk$p_total >= 0.05) {
+if (wk$p_overall_trend >= 0.05) {
 
   trend_description <- paste0(
     "There is no significant temporal trend in the time series ",
-    format_p(wk$p_total),
+    format_p(wk$p_overall_trend),
     "."
   )
 
-} else if (is.na(wk$p_nonlinear)) {
+} else if (is.na(wk$p_nonlinear_trend)) {
 
   if (!info$distribution %in% c("lognormal", "normal", "multinomial", "survival")) {
     stop("not coded for ", info$distribution, " distribution")
@@ -936,7 +936,7 @@ if (wk$p_total >= 0.05) {
     "There is a significant ",
     otrendtxt1,
     "trend in the time series ",
-    format_p(wk$p_linear),
+    format_p(wk$p_linear_trend),
     ". "
   )
 
@@ -998,7 +998,7 @@ if (wk$p_total >= 0.05) {
 
     trend_description <- paste0(
       "There is a significant trend in the time series ",
-      format_p(wk$p_total),
+      format_p(wk$p_overall_trend),
       " with levels stable until ",
       modelID,
       " and then ",
@@ -1018,9 +1018,9 @@ if (wk$p_total >= 0.05) {
 
     trend_description <- paste0(
       "There is a significant trend in the time series ",
-      format_p(wk$p_total),
+      format_p(wk$p_overall_trend),
       ". The trend is nonlinear ",
-      format_p(wk$p_nonlinear),
+      format_p(wk$p_nonlinear_trend),
       " so the shape of the trend must be assessed visually. ",
       change_txt("whole"),
       if (assessment$contrasts["whole", "start"] < wk_recent) change_txt("recent")
@@ -1032,9 +1032,9 @@ if (wk$p_total >= 0.05) {
 
     trend_description <- paste0(
       "There is a significant temporal trend in the time series ",
-      format_p(wk$p_total),
+      format_p(wk$p_overall_trend),
       ". The trend is nonlinear ",
-      format_p(wk$p_nonlinear),
+      format_p(wk$p_nonlinear_trend),
       " with levels stable until ",
       modelID,
       " followed by a nonlinear pattern of change which must be assessed visually. ",

--- a/inst/markdown/report_assessment.Rmd
+++ b/inst/markdown/report_assessment.Rmd
@@ -890,8 +890,8 @@ wk_recent <- info$max_year - info$recent.trend + 1
 
 
 change_txt <- function(type = c("whole", "recent")) {
-  p <- switch(type, whole = wk$pltrend, wk$prtrend)
-  trend <- switch(type, whole = wk$ltrend, wk$rtrend)
+  p <- switch(type, whole = wk$p_overall_change, wk$p_recent_change)
+  trend <- switch(type, whole = wk$overall_change, wk$recent_change)
   paste0(
     stringr::str_to_sentence(txt_concentrations),
     " at the end of the time series were ",
@@ -910,11 +910,11 @@ change_txt <- function(type = c("whole", "recent")) {
 }
 
 
-if (wk$p_overall >= 0.05) {
+if (wk$p_total >= 0.05) {
 
   trend_description <- paste0(
     "There is no significant temporal trend in the time series ",
-    format_p(wk$p_overall),
+    format_p(wk$p_total),
     "."
   )
 
@@ -924,7 +924,7 @@ if (wk$p_overall >= 0.05) {
     stop("not coded for ", info$distribution, " distribution")
   }
 
-  ltrend_txt1 <- switch(
+  otrendtxt1 <- switch(
     info$distribution,
     lognormal = "log-linear ",
     normal = "",
@@ -932,24 +932,24 @@ if (wk$p_overall >= 0.05) {
     survival = "log-linear"
   )
 
-  ltrend_txt2 <- paste0(
+  otrendtxt2 <- paste0(
     "There is a significant ",
-    ltrend_txt1,
+    otrendtxt1,
     "trend in the time series ",
     format_p(wk$p_linear),
     ". "
   )
 
-  ltrend_txt3 <- switch(
+  otrendtxt3 <- switch(
     info$distribution,
     lognormal = paste0(
       " by an estimated ",
-      round(100 * (exp(wk$ltrend / 100) - 1), 1),
+      round(100 * (exp(wk$overall_change / 100) - 1), 1),
       "% per year over the course of the time series."
     ),
     normal = paste(
       " by an estimated ",
-      format(wk$ltrend, digits = 2, nsmall = 0), info$unit_text,
+      format(wk$overall_change, digits = 2, nsmall = 0), info$unit_text,
       "per year over the course of the time series."
     ),
     multinomial = paste(
@@ -957,13 +957,13 @@ if (wk$p_overall >= 0.05) {
       if (is_AC && "EAC" %in% AC_id) paste0(
         " Formally, the odds of an individual exceeding the EAC in one year",
         " relative to the previous year is ",
-        format(exp(wk$ltrend), digits = 2, nsmall = 0),
+        format(exp(wk$overall_change), digits = 2, nsmall = 0),
         "."
       )
     ),
     survival = paste0(
       " by an estimated ",
-      round(100 * (exp(wk$ltrend / 100) - 1), 1),
+      round(100 * (exp(wk$overall_change / 100) - 1), 1),
       "% per year over the course of the time series."
     )
   )
@@ -974,11 +974,11 @@ if (wk$p_overall >= 0.05) {
     # not a change point model (currently only imposex)
 
     trend_description <- paste0(
-      ltrend_txt2,
+      otrendtxt2,
       stringr::str_to_sentence(txt_concentrations),
       " have ",
-      if (wk$ltrend > 0) "increased" else "decreased",
-      ltrend_txt3
+      if (wk$overall_change > 0) "increased" else "decreased",
+      otrendtxt3
     )
 
     if (info$good.status == "high") {
@@ -987,7 +987,7 @@ if (wk$p_overall >= 0.05) {
         "Higher values of",
         info$det_name,
         "indicate healthier organisms, so the trend suggests a",
-        if (wk$ltrend > 0) "improving" else "deteriorating",
+        if (wk$overall_change > 0) "improving" else "deteriorating",
         "situation."
       )
     }
@@ -998,11 +998,11 @@ if (wk$p_overall >= 0.05) {
 
     trend_description <- paste0(
       "There is a significant trend in the time series ",
-      format_p(wk$p_overall),
+      format_p(wk$p_total),
       " with levels stable until ",
       modelID,
       " and then ",
-      if (wk$ltrend > 0) "increasing" else "decreasing",
+      if (wk$overall_change > 0) "increasing" else "decreasing",
       " linear logistically. ",
       change_txt("whole"),
       if (assessment$contrasts["whole", "start"] < wk_recent) change_txt("recent")
@@ -1018,7 +1018,7 @@ if (wk$p_overall >= 0.05) {
 
     trend_description <- paste0(
       "There is a significant trend in the time series ",
-      format_p(wk$p_overall),
+      format_p(wk$p_total),
       ". The trend is nonlinear ",
       format_p(wk$p_nonlinear),
       " so the shape of the trend must be assessed visually. ",
@@ -1032,7 +1032,7 @@ if (wk$p_overall >= 0.05) {
 
     trend_description <- paste0(
       "There is a significant temporal trend in the time series ",
-      format_p(wk$p_overall),
+      format_p(wk$p_total),
       ". The trend is nonlinear ",
       format_p(wk$p_nonlinear),
       " with levels stable until ",
@@ -1049,11 +1049,11 @@ if (wk$p_overall >= 0.05) {
     trend_description <- paste(
       trend_description,
       "Note that ",
-      if (wk$ltrend > 0) "higher" else "lower",
+      if (wk$overall_change > 0) "higher" else "lower",
       "values of",
       info$det_name,
       "indicate",
-      if (wk$ltrend > 0) "healthier"else "less healthy",
+      if (wk$overall_change > 0) "healthier"else "less healthy",
       "organisms."
     )
   }
@@ -1282,7 +1282,7 @@ rm(list = intersect(
     "good_status", "group_id", "HQS_id",
     "id", "info", "info_multi", "intro_AMAP", "intro_txt",
     "is_AC", "is_BAC", "is_below", "is_EAC", "is_HQS", "is_normalised", "is_pred",
-    "is_ratio", "is_lognormal", "ltrend_txt",
+    "is_ratio", "is_lognormal", "otrendtxt",
     "nyear", "nyear_ok", "ok", "p_txt", "p_value", "page_title", "pred", "rv",
     "species_id",
     "status_description", "status_ok", "status_parametric", "status_nonparametric",


### PR DESCRIPTION
Resolves #483

In the output from `write_summary_table` have renamed:

- `p_linear_trend` as `p_overall_change`
- `p_recent_trend` as `p_recent change`
- `linear_trend` as `overall_change`
- `recent_trend` as recent_change`
- `p_overall` as `p_total`

These names better reflect the contents of the variables.  

I could have just renamed the columns in `write_summary_table`, but instead went and changed all the underlying instances of these variable (also called `pltrend`, `prtrend`, `ltrend`, `rtrend` in many places) so that these variables are now named consistently throughout.  .  

Tested on HELCOM and external data set.