### PR TITLE
missing header in write_summary_table

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       ## If we're pushing, which must be to main, upload the package as an artefact
       - name: Archive production artifacts
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package-distribution
           path: |

--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -428,7 +428,8 @@ ctsm.web.AC <- function(assessment_ob, classification) {
 #'
 #' @export
 write_summary_table <- function(
-  assessment_obj, output_file = NULL, output_dir = ".", export = TRUE,
+  assessment_obj, 
+  output_file = NULL, output_dir = ".", export = TRUE,
   collapse_AC = NULL, extra_output = NULL, 
   symbology = NULL, 
   determinandGroups = NULL, append = FALSE) {
@@ -793,15 +794,51 @@ write_summary_table <- function(
   }
   
 
-  # write summary to output_file or return summary object
-    
-  if (export) {
-    readr::write_excel_csv(summary, output_file, na = "", append = append)
-    return(invisible())
-  } else {
+  # results
+  
+  # if export = FALSE return summary data frame
+  
+  if (!export) {
     return(summary)
   }
     
+  
+  # otherwise write to output_file
+  
+  # headers on a new file aren't created if append = TRUE
+  
+  if (!file.exists(output_file)) {
+    append <- FALSE
+  }
+  
+  # if append = TRUE check that column names are identical and warn if there
+  # are series that are going to be repeated
+  
+  if (append) {
+    old_summary <- safe_read_file(output_file)
+    if (!identical(names(old_summary), names(summary))) {
+      stop(
+        "\nCannot append because the names of the new summary output differ ",
+        "from those of the\n", 
+        "existing summary file.",
+        call. = FALSE
+      )
+    }
+    
+    if (any(summary$series %in% old_summary$series)) {
+      warning(
+        "Some time series in the new summary output are already reported in ",
+        "the existing\n", 
+        "summary file: you should check what is going on.",
+        call. = FALSE
+      )
+    }
+  }
+  
+  
+  
+  readr::write_excel_csv(summary, output_file, na = "", append = append)
+  return(invisible())
 }
 
 


### PR DESCRIPTION
partially deals with #512 

A header is now always produced when a new summary table is written to file by `write_summary_table`.  Previously this did not happen if the `append` argument was set to `TRUE` and there was no existing summary file to append to.

Have also built in two checks when `append = TRUE`

- the function fails if the names of the new summary output are not identical to those in the existing summary csv file
- a warning is given if the any series identifier in the new summary output is present in the existing summary csv file.  This would indicate more than one set of results for the same time series and would require checking by the user.

Tested on data provided by @swamap