### PR TITLE
different samples treated as replicates

### DIFF
--- a/vignettes/external-file-format.Rmd
+++ b/vignettes/external-file-format.Rmd
@@ -32,7 +32,7 @@ The data file has one row for each measurement.
 | `sex` | character |  | see ICES reference codes for SEXCO<br>required for EROD assessments<br>desirable if sex is used to subdivide timeseries (see `subseries`) |
 | `n_individual` | integer |  | number of pooled individuals in the sample<br>required for imposex assessments  |
 | `subseries` | character |  | used to split up timeseries by e.g. sex or age<br>for example: `juvenile`, `adult_male`, `adult_female`<br>missing values indicate that all records in a timeseries will be considered together (no subdivision) |
-| `sample` | alphanumeric  | yes | links measurements made on the same individuals (biota), in the same sediment grab or in the same water sample<br>no missing values |
+| `sample` | alphanumeric  | yes | links measurements made on the same individuals (biota), in the same sediment grab or in the same water sample<br>no missing values<br>don't use the same value for samples collected in different years, at different stations or in different species |
 | `determinand` | character | yes | must match values in determinand reference table<br>most will be in ICES reference codes for PARAM but can provide own values<br>no missing values |
 | `matrix` | character  | yes | see ICES reference codes for MATRX |
 | `basis` | character | yes (biota & sediment) | `W`, `D` or `L`<br>no missing values for chemical measurements in biota or sediment<br>not mandatory for water where basis is always taken to be W |


### PR DESCRIPTION
resolves #512

Throws an error if there are any missing values in the `sample` column of the contaminants file.  (Only likely to happen with external data.)

Also checks for non-unique sample identifiers, for example when the same sample identifier has been used in different years, or for different stations or species.  If this occurs, then a warning is printed exhorting the user to sort out their contaminants data file.  But if they don't an attempt is made to create unique sample identifiers by pasting together `year`, `station_code`, `species` (biota only) and `sample`.  This should work in most situations.

Have updated the vignette on the external data file format to point out the need for unique sample identifiers (across years, stations, species, etc.)

Tested on HELCOM and external data