### PR TITLE
imposex assessments - all zero measurements

### DIFF
--- a/R/proportional_odds_functions.R
+++ b/R/proportional_odds_functions.R
@@ -12,7 +12,7 @@
 #' @export
 ctsm.VDS.varlist <- c(
   "ctsm.VDS.p.calc", "ctsm.VDS.loglik.calc", "ordinal_theta_est", 
-  "ordinal_theta_cl"
+  "ordinal_theta_cl", "ordinal_update_fit"
 )
 
 #' Detects the environment from the call


### PR DESCRIPTION
This concerns issue #500 and provides a partial fix which will suffice for the OSPAR 2025 assessment (and is a considerable improvement on what was done before).

The problem is how to get upper confidence limits on indices when all the measurements are zero.  A good way of doing this would be to use likelihood limits (rather than confidence limits) but this would involve a lot of coding and could be very computer intensive.

The fitted value for zero indices (on the latent scale) are infinity (large values on the latent scale equate to small indices) but it is not possible to construct confidence limits around these.  A pragmatic solution is to replace the infinite values with a suitably large value which, in particular, is bigger than all the fitted values for positive indices. This is done by taking all the positive indices, fitting a linear model of fitted value against square root index, and predicting what the fitted value should be when the index is zero.  The square root scale is based on the typical relationship between fitted value and index from the OSPAR 2025 assessment.

Similarly the standard error is taken to be the upper 90th quantile of the standard errors associated with the positive indices (with a suitable adjustment for the number of measurements used in each), since the standard errors get greater as the number of zero measurements increase (but in a not very predictable fashion).  

Having constructed sensible fitted values and standard errors, the confidence intervals are calculated in the standard way.

Tested on the OSPAR 2025 CEMP Assessment data

