### PR TITLE
Bug 539 - write_summary_table

### DIFF
--- a/R/imposex_clm.R
+++ b/R/imposex_clm.R
@@ -519,7 +519,7 @@ imposex_assess_clm <- function(
   summary$meanLY <- tail(output$pred$fit, 1)
   summary$clLY <- tail(output$pred$ci.upper, 1)
 
-  summary$class <- imposex_class(species, summary$clLY)
+  summary$imposex_class <- imposex_class(species, summary$clLY)
    
   summary <- within(summary, {
     # round for ease of interpretation

--- a/R/imposex_functions.R
+++ b/R/imposex_functions.R
@@ -270,21 +270,36 @@ assess_imposex <- function(
   }  
             
   
-  # now add on the comparison to ACs - common to both methods  
+  # now add on the comparison to ACs - common to both methods 
   
   summary[names(assessment$summary)] <- assessment$summary
   assessment$summary <- NULL
     
   ACsummary <- lapply(names(AC), function(i) {
+    value <- AC[i] 
     upperLimit <- with(summary, if (!is.na(clLY)) clLY else meanLY) 
-    diff <- upperLimit - AC[i]
-    setNames(data.frame(AC[i], diff), paste0(i, c("", "diff")))
+    diff <- upperLimit - value
+    
+    out <- data.frame(value, diff, achieved = NA_real_, below = NA_character_)
+    names(out) <- paste0(i, c("", "diff", "achieved", "below"))
+    out
   })
   
   ACsummary <- do.call(cbind, ACsummary)
   
   summary <- cbind(summary, ACsummary) 
-
+  
+  # move imposex class to end for consistency with other assessments
+  # create if it doesn't exist for completeness - this could be tidied up in a 
+  #   much needed general overhaul of imposex functions
+  
+  if ("imposex_class" %in% names(summary)) {
+    summary <- dplyr::relocate(summary, imposex_class, .after = last_col())
+  } else {
+    summary$imposex_class <- NA_character_
+  }
+    
+  
   output <- c(output, list(summary = summary), assessment)
 
   return(output)

--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -582,7 +582,6 @@ make_summary_table <- function(harsat_obj, extra_output, determinandGroups) {
 
   info <- harsat_obj$info
   
-  
   # merge stations with timeseries
 
   # get determinand group
@@ -707,7 +706,7 @@ make_summary_table <- function(harsat_obj, extra_output, determinandGroups) {
     
 
   # reorder variables and sort 
-  
+
   var_id <- c(
     "series", 
     info$region$id,  
@@ -1202,7 +1201,7 @@ group_thresholds <- function(summary, threshold_groups, thresholds) {
   # where some grouping is going on
     
   # lots of error trapping to catch anything stupid!
-    
+
   if (is.null(thresholds)) {
     stop(
       "threshold_groups specified but no thresholds used in the assessment", 


### PR DESCRIPTION
resolves #539

`write_summary_table` fails when only imposex data are assessed.  This is because the code expects to see four variables for each threshold (e.g. `BAC`, `BACdiff`, `BACachieved`, `BACbelow`) but the latter two are not used in an imposex assessment and so have not previously been created.  This isn't an issue when imposex data are part of a bigger assessment, because the missing variables are created for the other determinands and are then inherited by the imposex assessments.

Have resolved this by ensuring that, whenever a threshold is used, all the possible theshold variables are created (e.g. `BAC` `BACdiff`, `BACachieved`, `BACbelow`).  This was already the case for all determinands apart from imposex.  Some of these variables will be empty, but it means that the output in the summary tables will be consistent across determinands / assessments.

Also corrected a bug in the code that sometimes created the variable `class` instead of the intended variable `imposex_class`.

Tested on UK imposex data.  

And (apologies) I think the only changes in reporting_functions are deletions and insertions of blank lines!