### PR TITLE
Bug 524 normalisation France metals region 2

### DIFF
--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -4439,7 +4439,7 @@ convert_to_target_basis <- function(data, info, get_basis) {
 }
 
 
-#' Normalises sediment concentrations, OSPAR vwersion
+#' Normalises sediment concentrations, OSPAR version
 #' 
 #' @param data the data object
 #' @param station_dictionary the station dictionary
@@ -4717,7 +4717,7 @@ normalise_sediment_OSPAR <- function(data, station_dictionary, info, control) {
             "France" %in% station_dictionary$country) {
           
           station_id <- station_dictionary$country %in% "France" & 
-            station_dictionary$OSPAR_region %in% "2"
+            station_dictionary$ospar_region %in% "2"
           station_id <- station_dictionary[station_id, "station_code"]
           id <- data$station_code %in% station_id
           

--- a/man/normalise_sediment_OSPAR.Rd
+++ b/man/normalise_sediment_OSPAR.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/import_functions.R
 \name{normalise_sediment_OSPAR}
 \alias{normalise_sediment_OSPAR}
-\title{Normalises sediment concentrations, OSPAR vwersion}
+\title{Normalises sediment concentrations, OSPAR version}
 \usage{
 normalise_sediment_OSPAR(data, station_dictionary, info, control)
 }
@@ -16,5 +16,5 @@ normalise_sediment_OSPAR(data, station_dictionary, info, control)
 \item{control}{control values}
 }
 \description{
-Normalises sediment concentrations, OSPAR vwersion
+Normalises sediment concentrations, OSPAR version
 }


### PR DESCRIPTION
Resolves #524

Have replaced `OSPAR_region` with `ospar_region` so that the correct pivot values are picked up for France in the OSPAR assessment.  This was overlooked when migrating the code to harsat a long time ago!