### PR TITLE
symbology for summary tables - part 6

### DIFF
--- a/vignettes/example_HELCOM.Rmd.orig
+++ b/vignettes/example_HELCOM.Rmd.orig
@@ -209,8 +209,28 @@ the assessment of each time series. This includes:
 - (optionally) a symbology summarising the trend (shape) and status (colour)
   of each time series
 
-This function is being actively developed and the function arguments are 
-likely to evolve, so we'll leave their explanation for the next release.
+The default symbology is used here which summarises the trend as:  
+
+- small_open_circle: one or two years of data (no model fitted)  
+- small_filled_circle: three or four years of data, so only the mean 
+  concentration is estimated (no trend fitted)
+- large_filled_circle: no significant change in concentration in the last
+  twenty years (p > 0.05)
+- upward_triangle: significant increase in concentration in the last twenty 
+  years (p < 0.05)
+- downward_triangle: significant decrease in concentration in the last twenty 
+  years (p < 0.05)
+  
+The status is summarised as:  
+
+- green: the mean concentration in the most recent year is significantly below
+  the EQS (p < 0.05)
+- red: the mean concentration in the most recent year is not significantly 
+  below the EQS (p > 0.05)
+
+Many aspects of the symbology can be controlled using the `symbology_control` 
+argument. Users can also supply their own function to customise the symbology
+to suit their needs. 
 
 
 ```{r helcom-water-summary}
@@ -306,7 +326,10 @@ check_assessment(sediment_assessment)
 ```
 
 Finally, we can plot individual time series assessments (see vignette for
-external data) or print out the summary table
+external data) or print out the summary table. The `determinandGroups` argument
+allows the determinand groupings (as defined in the determinand reference table) 
+to be renamed in the summary table. Below both the PBDEs and Organobromines 
+groups would appear as Organobromines in the summary table. 
 
 ```{r helcom-sediment-summary}
 write_summary_table(
@@ -317,7 +340,7 @@ write_summary_table(
       EQS = list(below = "green", above = "red")
     )
   ),
-  determinandGroups = webGroups <- list(
+  determinandGroups = list(
     levels = c("Metals", "Organotins", "PAH_parent", "PBDEs", "Organobromines"),  
     labels = c(
       "Metals", "Organotins", "Polycyclic aromatic hydrocarbons",  
@@ -452,8 +475,13 @@ biota_assessment <- update_assessment(
 check_assessment(biota_assessment)
 ```
 
-
-And that's it :)
+The assessment uses four types of thresholds (BAC, EAC, EQS and MPC), but 
+only one of them is applied to each timeseries, and they are all used to 
+delineate between good and poor status.  The summary table can therefore be 
+simplified by grouping the thresholds together using the `threshold_groups` 
+argument and labelling them as an EQS (equivalent). The symbology then 
+knows that, whichever threshold is applied, the status will be green if 
+significantly below the threshold and red otherwise.
 
 ```{r helcom-biota-summary}
 write_summary_table(

--- a/vignettes/example_OSPAR.Rmd.orig
+++ b/vignettes/example_OSPAR.Rmd.orig
@@ -106,6 +106,12 @@ if (!dir.exists(summary.dir)) {
 ```{r ospar-water-summary}
 write_summary_table(
   water_assessment,
+  symbology = "default",
+  symbology_control = list(
+    colour = list(
+      EQS = list(below = "green", above = "red")
+    )
+  ),
   determinandGroups = list(
     levels = c(
       "Metals", "Organotins", "PAH_parent",  "Organofluorines", 
@@ -114,12 +120,6 @@ write_summary_table(
     labels = c(
       "Metals", "Organotins", "PAH parent compounds", "Organofluorines", 
       "Polychlorinated biphenyls", "Organochlorines (other)", "Pesticides"
-    )
-  ),
-  symbology = "default",
-  symbology_control = list(
-    colour = list(
-      EQS = list(below = "green", above = "red")
     )
   ),
   output_dir = summary.dir
@@ -207,10 +207,36 @@ sediment_assessment <- run_assessment(
 check_assessment(water_assessment)
 ```
 
+The summary table groups the thresholds into the BAC and a set of EAC 
+equivalents. The thresholds are then listed  from best 
+to worst status in `symbology_control` and each timeseries is characterised as:  
+
+- blue: mean concentration (in the most recent year) significantly below the BAC 
+  (p < 0.05)
+- orange: mean concentration not significantly below the BAC (p > 0.05) and no
+  EAC
+- green: mean concentration significantly below the EAC (p < 0.05)
+- red: mean concenctration not significantly below the EAC (p > 0.05)
+
+Timeseries are characterised as black if there are no applicable thresholds, 
+although this behaviour can be modified using `symbology_control`.
+
+
 
 ```{r ospar-sediment-summary}
 write_summary_table(
   sediment_assessment,
+  threshold_groups = list(
+    BAC = "BAC", 
+    EAC = c("EAC", "ERL", "EQS", "FEQG")
+  ),
+  symbology = "default", 
+  symbology_control = list(
+    colour = list(
+      BAC = list(below = "blue", above = "orange"),
+      EAC = list(below = "green", above = "red")
+    )
+  ),
   determinandGroups = list(
     levels = c(
       "Metals", "Organotins", "PAH_parent", "PAH_alkylated",  
@@ -221,17 +247,6 @@ write_summary_table(
       "Metals", "Organotins", "PAH parent compounds", "PAH alkylated compounds", 
       "Polybrominated diphenyl ethers", "Organobromines (other)", 
       "Polychlorinated biphenyls", "Dioxins", "Organochlorines (other)"
-    )
-  ),
-  threshold_groups = list(
-    BAC = "BAC", 
-    EAC = c("EAC", "ERL", "EQS", "FEQG")
-  ),
-  symbology = "default", 
-  symbology_control = list(
-    colour = list(
-      BAC = list(below = "blue", above = "orange"),
-      EAC = list(below = "green", above = "red")
     )
   ),
   output_dir = summary.dir
@@ -376,15 +391,38 @@ check_assessment(biota_assessment)
 
 
 
-We now write the summary table. Here the symbology is based on environmental 
-thresholds. A separate call would be needed to get the symbology based on health 
-thresholds. The symbology functionality is still under development and it is 
-intended to allow both sets of symbologies to be calculated with a single call.
+We now write the summary table. There are now three groups of thresholds: BAC 
+equivalents, EAC equivalents and HQS (human health quality standard) equivalents. 
+Two symbologies are produced, one using the environmental thresholds (BAC and 
+EAC), the other using the health threshold (HQS). The `symbology` argument
+says that they are both based on the default symbology function and assigns 
+names to each to link to the `symbology_control` argument. This then specifices
+which thresholds and colours are to be used in each symbology and gives names
+to the symbology variables so that are do not get confused in the summary table.
 
 
 ```{r ospar-biota-summary}
 write_summary_table(
   biota_assessment,
+  threshold_groups = list(
+    BAC = c("BAC", "NRC"),
+    EAC = c("EAC", "FEQG", "LRC", "QSsp"), 
+    HQS = c("MPC", "QShh")
+  ),
+  symbology = list(env = "default", health = "default"), 
+  symbology_control = list(
+    env = list(
+      colour = list(
+        BAC = list(below = "blue", above = "orange"),
+        EAC = list(below = "green", above = "red")
+      ), 
+      names = list(shape = "shape_env", colour = "colour_env")
+    ),
+    health = list(
+      colour = list(HQS = list(below = "green", above = "red")), 
+      names = list(shape = "shape_health", colour = "colour_health")
+    )
+  ),
   determinandGroups = list(
     levels = c(
       "Metals", "Organotins",
@@ -401,18 +439,6 @@ write_summary_table(
       "Organofluorines",
       "Polychlorinated biphenyls", "Dioxins", "Organochlorines (other)",
       "Biological effects (other)"
-    )
-  ),
-  threshold_groups = list(
-    BAC = c("BAC", "NRC"),
-    EAC = c("EAC", "FEQG", "LRC", "QSsp"), 
-    HQS = c("MPC", "QShh")
-  ),
-  symbology = "default",
-  symbology_control = list(
-    colour = list(
-      BAC = list(below = "blue", above = "orange"),
-      EAC = list(below = "green", above = "red")
     )
   ),
   output_dir = summary.dir

--- a/vignettes/example_external_data.Rmd.orig
+++ b/vignettes/example_external_data.Rmd.orig
@@ -154,7 +154,7 @@ write_summary_table(
   export = TRUE,
   determinandGroups = NULL,
   symbology = NULL,
-  collapse_AC = NULL, 
+  threshold_goups = NULL, 
   extra_output = "power"
 )
 ```


### PR DESCRIPTION
See issues https://github.com/osparcomm/HARSAT/issues/149 and https://github.com/osparcomm/HARSAT/issues/417 and pull requests https://github.com/osparcomm/HARSAT/pull/532, https://github.com/osparcomm/HARSAT/pull/533 and https://github.com/osparcomm/HARSAT/pull/534 and https://github.com/osparcomm/HARSAT/pull/537 and #538

Have added explanation to the vignettes to explain the recent changes to `write_summary_table`; particularly, how the arguments `threshold_groups`, `symbology` and `symbology_control` can be used.