### PR TITLE
Bug 544 error when reading HELCOM extraction

### DIFF
--- a/R/import_functions.R
+++ b/R/import_functions.R
@@ -1362,46 +1362,81 @@ add_stations <- function(data, stations, info){
   
   # deal with degenerate case where station_longituderange or 
   # station_latituderange equals zero (so polygon collapses to a line)
+  
+  # 11/11/25 
+  # now working with station geometries directly, rather than trusting 
+  # latitude and longitude ranges (which are derived from the geometries, but
+  # reported with fewer dp)
+  # have commmented out the code in case it will be of use lated to with 
+  # stations such as 13771 (see below) which condense to a point
 
-  ok <- stations$station_longituderange > 0 & stations$station_latituderange > 0
-  if (!all(ok)) {
+  # ok <- stations$station_longituderange > 0 & stations$station_latituderange > 0
+  # if (!all(ok)) {
+  #   stations <- split(stations, ok)
+  #   stations[["FALSE"]] <- dplyr::mutate(
+  #     stations[["FALSE"]], 
+  #     station_longituderange = pmax(.data$station_longituderange, 0.000001),
+  #     station_latituderange = pmax(.data$station_latituderange, 0.000001)
+  #   )
+  #   stations[["FALSE"]]$station_geometry <- mapply(
+  #     FUN = function(longitude, latitude, longituderange, latituderange) {
+  #       point <- c(longitude, latitude)
+  #       range <- c(longituderange, latituderange)
+  #       mult <- c(1, 1, -1, 1, -1, -1, 1, -1, 1, 1)
+  #       polygon <- rep(point, 5) + rep(range, 5) * mult
+  #       polygon <- matrix(polygon, ncol = 2, byrow = TRUE)
+  #       geom <- sf::st_geometrycollection(
+  #         c(sf::st_point(point), sf::st_polygon(list(outer = polygon)))
+  #       )  
+  #       sf::st_as_text(geom)
+  #     },
+  #     longitude = stations[["FALSE"]]$station_longitude,
+  #     latitude = stations[["FALSE"]]$station_latitude,
+  #     longituderange = stations[["FALSE"]]$station_longituderange,
+  #     latituderange = stations[["FALSE"]]$station_latituderange,
+  #     USE.NAMES = FALSE
+  #   )
+  #   stations <- unsplit(stations, ok)      
+  # }
+  
+  
+  # check station geometries are valid (for matching by co-ordinates)
+  # 
+  # 11/11/25 four invalid polygons
+  # one of these (station_code = 13771) is an underwater noise station, which 
+  # arguably should be just a point
+  # for some reason, which I can't fathom, the nominal station latitude and 
+  # longitude don't intersect with the repaired geometry which has condensed 
+  # into a point; the nominal co-ordinates and repaired geometry are all.equal
+  # but not identical
+  # have left this for now, as very unlikely to be an issue
+  
+  stations <- sf::st_as_sf(
+    stations,
+    wkt = "station_geometry",
+    crs = sf::st_crs(4326)
+    # 4326 is the EPSG code for the datum/projection used (https://epsg.io/4326). 
+    # It needs to be specified so that the spatial functions know what 
+    # coordinate system should be used when calculating distance/area etc. 
+    # The 4326 is the WGS84 system used by most GPS systems        
+  )
 
-    stations <- split(stations, ok)
-
-    stations[["FALSE"]] <- dplyr::mutate(
-      stations[["FALSE"]], 
-      station_longituderange = pmax(.data$station_longituderange, 0.000001),
-      station_latituderange = pmax(.data$station_latituderange, 0.000001)
+  ok <- sf::st_is_valid(stations)
+  if (any(!ok)) {
+    id <- stations$station_code[!ok]
+    warning(
+      "these stations have invalid shape file polygons:\n",
+      paste(id, collapse = ", "), 
+      "\nthe code has 'repaired' the polygons, but please inform ICES so that ",
+      "they\ncan be fixed at source",
+      call. = FALSE, 
+      immediate. = TRUE
     )
-     
-    stations[["FALSE"]]$station_geometry <- mapply(
-      FUN = function(longitude, latitude, longituderange, latituderange) {
-        point <- c(longitude, latitude)
-        
-        range <- c(longituderange, latituderange)
-        mult <- c(1, 1, -1, 1, -1, -1, 1, -1, 1, 1)
-        
-        polygon <- rep(point, 5) + rep(range, 5) * mult
-        polygon <- matrix(polygon, ncol = 2, byrow = TRUE)
-      
-        geom <- sf::st_geometrycollection(
-          c(sf::st_point(point), sf::st_polygon(list(outer = polygon)))
-        )  
-      
-        sf::st_as_text(geom)
-      },
-      longitude = stations[["FALSE"]]$station_longitude,
-      latitude = stations[["FALSE"]]$station_latitude,
-      longituderange = stations[["FALSE"]]$station_longituderange,
-      latituderange = stations[["FALSE"]]$station_latituderange,
-      USE.NAMES = FALSE
-    )
-      
-    stations <- unsplit(stations, ok)      
-
   }
   
-  
+  stations <- sf::st_make_valid(stations)
+
+
   # create the datatype variable for matching (if required) 
 
   wk <- switch(info$compartment, biota = "F", sediment = "S", water = "W")
@@ -1562,23 +1597,23 @@ add_stations <- function(data, stations, info){
         
       } 
       
-      sd <- sf::st_as_sf(
-        stations_subset,
-        wkt = "station_geometry",
-        crs = sf::st_crs(4326)
-        # 4326 is the EPSG code for the datum/projection used (https://epsg.io/4326). 
-        # It needs to be specified so that the spatial functions know what 
-        # coordinate system should be used when calculating distance/area etc. 
-        # The 4326 is the WGS84 system used by most GPS systems        
-      )
+      # sd <- sf::st_as_sf(
+      #   stations_subset,
+      #   wkt = "station_geometry",
+      #   crs = sf::st_crs(4326)
+      #   # 4326 is the EPSG code for the datum/projection used (https://epsg.io/4326). 
+      #   # It needs to be specified so that the spatial functions know what 
+      #   # coordinate system should be used when calculating distance/area etc. 
+      #   # The 4326 is the WGS84 system used by most GPS systems        
+      # )
       
       dpoint <- sf::st_point(c(file$longitude,file$latitude))
       dpoint_sfc <- sf::st_sfc(dpoint)
       dpoint_sfc_4326 <- sf::st_set_crs(dpoint_sfc, 4326)
       
-      sd1 <- sd[dpoint_sfc_4326, op = sf::st_intersects]
+      sd1 <- stations_subset[dpoint_sfc_4326, op = sf::st_intersects]
       
-      if(nrow(sd1)> 1){
+      if (nrow(sd1) > 1) {
         
         part <- data.frame()
         for(i in 1:nrow(sd1)) {
@@ -1605,7 +1640,7 @@ add_stations <- function(data, stations, info){
         result <- dplyr::mutate(file, station_code = sd1$station_code)
         res <- rbind(res, result)
         
-      } else if(nrow(sd1)==1) {
+      } else if (nrow(sd1) == 1) {
         
         result <- dplyr::mutate(file, station_code = sd1$station_code)
         res <- rbind(res, result)
@@ -1640,6 +1675,17 @@ add_stations <- function(data, stations, info){
   
   cat(" - matching", nrow(x_name), "records by station name\n")
 
+  
+  # remove geometry here as it speeds up code (not needed when matching by name)
+  
+  wkt_geometry <- sf::st_geometry(stations)
+  wkt_geometry <- sf::st_as_text(wkt_geometry)
+  
+  stations <- sf::st_drop_geometry(stations)
+  
+  stations$station_geometry <- wkt_geometry
+  
+  
   if (nrow(x_name) > 0L) {
   
     id <- c(


### PR DESCRIPTION
Resolves #544

`read_data` failed because there were four invalid geometries in the station dictionary. Three of these were badly defined polygons (with e.g. repeated verticies leading to line features). The fourth (`station_code` 13771) is an underwater noise station with a polygon that collapses to a point. 

The code now repairs invalid geometries using `sf::st_make_valid` and everything is fine (apart from a minor glitch below).  Have tested on a recent HELCOM biota extraction and the biota extraction for the preliminary 2026 OSPAR assessment. 

Have also commented out some redundant code that historically did repairs for stations with a zero latitude or longitude range.

The one remaining glitch is station 13771 where the repaired station is a point but which, for some reason, will not intersect with the nominal station co-ordinates.  As it is an underwater noise station, this is unlikely to be of concern, but will be noted in a new issue which will look to base all the code on geometries, rather than the output nominal coordinates.

