### PR TITLE
Bug in report_assessment when too many related compounds

### DIFF
--- a/R/graphics_functions.R
+++ b/R/graphics_functions.R
@@ -1321,8 +1321,8 @@ plot.panel <- function(
     type, 
     data = 2.5, 
     index = 2,
-    ratio_mp = switch(layout.row, 2.0, 1.4, 0.9, 0.7, 0.6), 
-    index_mp = switch(layout.row, 2.0, 1.4, 0.9, 0.7, 0.6) 
+    ratio_mp = switch(layout.row, 2.0, 1.4, 0.9, 0.7, 0.6, 0.5, 0.4), 
+    index_mp = switch(layout.row, 2.0, 1.4, 0.9, 0.7, 0.6, 0.5, 0.4) 
   )
   
   wk.pch <- switch(
@@ -1676,6 +1676,13 @@ plot_multiassessment <- function(data, assessment, series, info, ...) {
   # silence non-standard evaluation warnings
   .data <- NULL
 
+  if (length(series$seriesID) >= 50L) {
+    stop(
+      "50 or more series are too many to show meaningfully in a single plot",
+      call. = FALSE
+    )
+  }
+  
   is.data <- sapply(assessment, function(i) !is.null(i))
   
   is.pred <- sapply(assessment, function(i) !is.null(i) && !is.null(i$pred))
@@ -1766,7 +1773,9 @@ plot_multiassessment <- function(data, assessment, series, info, ...) {
   add.xlab = 1:ndet <= layout.col
   names(add.xlab) <- series$seriesID
 
-  xykey.cex <- switch(layout.row, 1.4, 1.1, 0.9, 0.7, 0.6)
+  xykey.cex <- switch(
+    layout.row, 1.4, 1.1, 0.9, 0.7, 0.6, 0.5, 0.4
+  )
 
 
   # sets up viewport so that assessment concentrations and ylabel fit correctly
@@ -2308,6 +2317,12 @@ plot_ratio <- function(data, series, info, ...) {
     Organochlorines = c("DDEPP / DDTPP", "DDTOP / DDTPP")
   )
   
+  if (length(ratio_id) > 4L) {
+    stop(
+      "only 4 ratios can currently be plotted - contact harsat development team",
+      call. = FALSE
+    )
+  }
   
   numerator_id <- switch(
     series$group,
@@ -2462,7 +2477,7 @@ plot_ratio <- function(data, series, info, ...) {
   add.xlab = 1:ndet <= layout.col
   names(add.xlab) <- ratio_id
   
-  xykey.cex <- switch(layout.row, 1.4, 1.1, 0.9, 0.7, 0.6)
+  xykey.cex <- switch(layout.row, 1.4, 1.1, 0.9, 0.7, 0.6, 0.5, 0.4)
   ref.cex <- switch(layout.row, 1.2, 1.0)
   
   # get positions for plotting reference text  

--- a/inst/markdown/report_assessment.Rmd
+++ b/inst/markdown/report_assessment.Rmd
@@ -104,11 +104,19 @@ data <- assessment_object$data[ok, ]
 
 assessment <- assessment_object$assessment[[params$series]]
 
-info <- assessment_object$info[c(
+# the following ensures all the elements are present in info (perhaps as NULL)
+# even if not present in assessment_object$info
+# for example, AC might not be a named element of assessment_object$info
+
+info <- list()
+
+info_id <- c(
   "compartment", "purpose", "extraction", "max_year", "reporting_window", 
   "recent_years", "recent.trend", "AC", "normalise"
-)]
-  
+)
+
+info[info_id] <- assessment_object$info[info_id]
+
 info <- c(info, assessment_object$timeSeries[params$series, ])
 
 # determinand info
@@ -736,15 +744,27 @@ plot_auxiliary(data, assessment, info, assessment_object$info, auxiliary = auxil
 #### Assessments (related `r txt_compounds`)
 
 ```{r, include = FALSE}
-ok <- ! info$detGroup %in% "Imposex"
+not_ok1 <- length(info_multi$seriesID) == 1L
+not_ok2 <- length(info_multi$seriesID) >= 50L
+ok <- !not_ok1 & !not_ok2
+
 if (info$determinand == "EROD") {
   info_multi$subseries <- NA_character_
 }
 ```
 
-```{asis, eval = !ok}
+```{asis, eval = not_ok1}
 <br>
-No related responses assessed.
+No related `r txt_compounds` assessed.  
+<br>
+<br>
+```
+
+```{asis, eval = not_ok2}
+<br>
+Too many related `r txt_compounds` to show meaningfully in a single plot.  
+<br>
+<br>
 ```
 
 ```{r multi_assessment, eval = ok, echo = FALSE, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 7}
@@ -757,12 +777,23 @@ plot_multiassessment(
 #### Data (related `r txt_compounds`)
 
 ```{r, include = FALSE}
-ok <- ! info$detGroup %in% "Imposex"
+not_ok1 <- length(info_multi$seriesID) == 1L
+not_ok2 <- length(info_multi$seriesID) > 20L
+ok <- !not_ok1 & !not_ok2
 ```
 
-```{asis, eval = !ok}
+```{asis, eval = not_ok1}
 <br>
-No related responses assessed.
+No related `r txt_compounds` assessed.  
+<br>
+<br>
+```
+
+```{asis, eval = not_ok2}
+<br>
+Too many related `r txt_compounds` to show meaningfully in a single plot.  
+<br>
+<br>
 ```
 
 ```{r multi_data, eval = ok, echo = FALSE, message = FALSE, warning = FALSE, fig.width = 9, fig.height = 7}


### PR DESCRIPTION
See #550 error 2

`report_assessment` throws an error when trying to run `plot_multiassessment` when there are more than 25 related responses. This occurs because the layout and related graphics parameters are only coded for a maximum of a 5 x 5 array of plots (i.e. 25 related assessments).  

The code has been extended to deal with a maximum of a 7 x 7 array of plots (i.e. 49 related assessments). If this is exceeded, then the plot is not produced, a message appears to say that there are too many related compounds to produce a meaningful plot, and `report_assessment` runs to completion.

Have also changed the code so that `plot_multidata` is only run if there are 20 or less related compounds, with a message produced otherwise to say that there are too many related compounds to produce a meaningful plot.  `plot_multidata` increases in complexity as the square of the number of compounds, so cannot accommodate (sensibly) as many compounds as `plot_multiassessment`.  The choice of 20 is arbritrary and is arguably too many. 

Have tested this on the data that produced the original error and on several timeseries from the 2026 OSPAR assessment.

