### PR TITLE
Add a timestamp to write_summary_table

### DIFF
--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -544,7 +544,7 @@ write_summary_table <- function(
   
   # create timestamp if timestamp = TRUE
 
-  if (timestamp) {  
+  if (isTRUE(timestamp)) {  
     summary$timestamp <- Sys.time()
     summary <- dplyr::relocate(summary, timestamp)
   }    

--- a/R/reporting_functions.R
+++ b/R/reporting_functions.R
@@ -230,6 +230,9 @@ ctsm.web.AC <- function(assessment_ob, classification) {
 #' @param determinandGroups optional, a list specifying `labels` and `levels`
 #'   to rename the existing determinand groups. The life of this argument is 
 #'   limited.
+#' @param timestamp Logical. `FALSE` (the detault) does nothing. `TRUE` outputs
+#'   an extra column with the date and time that the summary file was created. 
+#'   Most likely only useful if you are using `append` (see below). 
 #' @param append Logical. `FALSE` (the default) overwrites any existing summary
 #'   file. `TRUE` appends data to it, creating it if it does not yet exist.
 #'
@@ -446,6 +449,7 @@ write_summary_table <- function(
   symbology = NULL, 
   symbology_control = list(),
   determinandGroups = NULL, 
+  timestamp = FALSE, 
   append = FALSE) {
 
   if (lifecycle::is_present(collapse_AC)) {
@@ -506,7 +510,7 @@ write_summary_table <- function(
   
 
   # otherwise write to .csv file
-    
+  
   # get default output_file 
   
   if (is.null(output_file)) {
@@ -536,7 +540,14 @@ write_summary_table <- function(
       call. = FALSE
     )
   }
+
   
+  # create timestamp if timestamp = TRUE
+
+  if (timestamp) {  
+    summary$timestamp <- Sys.time()
+    summary <- dplyr::relocate(summary, timestamp)
+  }    
 
   # headers on a new file aren't created if append = TRUE
   

--- a/man/write_summary_table.Rd
+++ b/man/write_summary_table.Rd
@@ -15,6 +15,7 @@ write_summary_table(
   symbology = NULL,
   symbology_control = list(),
   determinandGroups = NULL,
+  timestamp = FALSE,
   append = FALSE
 )
 }
@@ -60,6 +61,10 @@ the symbology. See details.}
 \item{determinandGroups}{optional, a list specifying \code{labels} and \code{levels}
 to rename the existing determinand groups. The life of this argument is
 limited.}
+
+\item{timestamp}{Logical. \code{FALSE} (the detault) does nothing. \code{TRUE} outputs
+an extra column with the date and time that the summary file was created.
+Most likely only useful if you are using \code{append} (see below).}
 
 \item{append}{Logical. \code{FALSE} (the default) overwrites any existing summary
 file. \code{TRUE} appends data to it, creating it if it does not yet exist.}


### PR DESCRIPTION
resolves #562 

`write_summary_table` now produces a timestamp (as the first column of the summary table) if argument `timestamp` is set to `TRUE`.  The default is not to produce a timestamp.  

Tested on AMAP external data example