### PR TITLE
Update external data example

### DIFF
--- a/vignettes/example_external_data.Rmd.orig
+++ b/vignettes/example_external_data.Rmd.orig
@@ -151,10 +151,6 @@ write_summary_table(
   biota_assessment,
   output_file = "biota-FO-PW-test-output.csv",   # NB, file will be overwritten so change name as appropriate to retain results
   output_dir = summary.dir,
-  export = TRUE,
-  determinandGroups = NULL,
-  symbology = NULL,
-  threshold_goups = NULL, 
   extra_output = "power"
 )
 ```


### PR DESCRIPTION
Have updated the call to `write_summary_table` in the vignette showing an example run of external data.  The code should have been updated a while ago (when the symbologies were updated), but it was missed.